### PR TITLE
Update Copilot and Darwin config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772985280,
-        "narHash": "sha256-FdrNykOoY9VStevU4zjSUdvsL9SzJTcXt4omdEDZDLk=",
+        "lastModified": 1773681845,
+        "narHash": "sha256-o8hrZrigP0JYcwnglCp8Zi8jQafWsxbDtRRPzuVwFxY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8f736f007139d7f70752657dff6a401a585d6cbc",
+        "rev": "0759e0e137305bc9d0c52c204c6d8dffe6f601a6",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772822230,
-        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
+        "lastModified": 1773814637,
+        "narHash": "sha256-GNU+ooRmrHLfjlMsKdn0prEKVa0faVanm0jrgu1J/gY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "rev": "fea3b367d61c1a6592bc47c72f40a9f3e6a53e96",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1771788390,
-        "narHash": "sha256-RzBpBwn93GWxLjacTte+ngwwg0L/BVOg4G/sSIeK3Rw=",
+        "lastModified": 1773790548,
+        "narHash": "sha256-6lI+ZM1yWL4cNRT39s8AUC+kwq237PZCrWc1ubLOwqc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ebb238f14d6f930068be4718472da3105fd5d3bf",
+        "rev": "e8ffdddd42062ebc90178db9d013aa38c20b7b2f",
         "type": "github"
       },
       "original": {

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -1,6 +1,23 @@
 # Common home-manager configuration shared between Linux and Darwin
 { config, pkgs, lib, ... }:
 
+let
+  copilotInstructionsFileName = "copilot-defaults.instructions.md";
+  copilotInstructionsText = ''
+    ---
+    description: "Use for every task. Persistent defaults for terminal commands, shell usage, and command logging. Prefer non-interactive commands and log command plus output to ~/.cache/copilot."
+    name: "Persistent Terminal Logging Defaults"
+    applyTo: "**"
+    ---
+    # Persistent Terminal Defaults
+
+    - Prefer non-interactive commands over interactive shells unless the task explicitly requires an interactive program.
+    - Minimize use of interactive terminal flows that can mangle command output in the IDE.
+    - When running terminal commands, also write the exact command and the resulting output to files under ~/.cache/copilot.
+    - Ensure ~/.cache/copilot exists before attempting to write logs there.
+    - Use append-safe logging or timestamped files so earlier command logs are not lost unless replacement is explicitly intended.
+  '';
+in
 {
   nixpkgs.config = {
     allowUnfree = true;
@@ -15,6 +32,20 @@
 
   # Ensure user-local binaries are found regardless of shell
   home.sessionPath = lib.mkBefore [ "$HOME/.local/bin" ];
+
+  home.file = lib.mkMerge [
+    (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+      "Library/Application Support/Code/User/prompts/${copilotInstructionsFileName}".text = copilotInstructionsText;
+    })
+    (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+      ".config/Code/User/prompts/${copilotInstructionsFileName}".text = copilotInstructionsText;
+      ".vscode-server/data/User/prompts/${copilotInstructionsFileName}".text = copilotInstructionsText;
+    })
+  ];
+
+  home.activation.ensureCopilotCacheDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    mkdir -p "$HOME/.cache/copilot"
+  '';
 
   # Common packages (platform-agnostic)
   home.packages = with pkgs; [
@@ -114,6 +145,8 @@
       gtk.enable = true;
       kde.enable = true;
       vscode.enable = true;
+      # Temporary disabled due to LLVM/Zig build issues causing build failures on macOS
+      firefox.enable = lib.mkForce false;
       starship.enable = true;
       # Keep qt disabled unless explicitly requested as the override is causing issues
       qt.enable = false;
@@ -139,6 +172,7 @@
             args = [ "-l" ];
           };
         };
+        "terminal.integrated.shellIntegration.enabled" = true;
 
         # Small quality-of-life defaults (non-Stylix)
         "editor.fontLigatures" = true;

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -28,6 +28,11 @@
         alias ssh="kitty +kitten ssh"
       fi
 
+      # Enable VS Code terminal shell integration even with custom zsh init.
+      if [[ "$TERM_PROGRAM" == "vscode" ]] && command -v code >/dev/null 2>&1; then
+        source "$(code --locate-shell-integration-path zsh)"
+      fi
+
       # Initialize shell integrations
       eval "$(zoxide init zsh)"
 

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -73,8 +73,9 @@ auth       sufficient     pam_tid.so
     fi
   '';
 
-  # Strip quarantine from Flameshot after Homebrew installs it to bypass Gatekeeper
-  system.activationScripts.postUserActivation.text = ''
+  # Strip quarantine from Flameshot after Homebrew installs it to bypass Gatekeeper.
+  # nix-darwin activation now runs as root, so a regular activation script is sufficient.
+  system.activationScripts.flameshotQuarantineFix.text = ''
     if [ -d "/Applications/Flameshot.app" ]; then
       echo "Stripping quarantine attribute from Flameshot..."
       xattr -cr /Applications/Flameshot.app || true
@@ -228,6 +229,7 @@ auth       sufficient     pam_tid.so
       "git"
       "golang"
       "go-task"
+      "jira-cli"
       "jq"
       "kion-cli"
       "lima-additional-guestagents"


### PR DESCRIPTION
## Summary
- add persistent user-level Copilot instructions and ensure the Copilot cache directory exists across managed profiles
- enable VS Code shell integration defaults in the shared Home Manager and zsh configuration
- update nix-darwin activation for the Flameshot quarantine fix and add jira-cli to the macOS Homebrew profile
- refresh flake inputs used by the configuration

## Testing
- task darwin-build HOST=ICFGG241C3Y03
