### PR TITLE
Extract Copilot instructions file

### DIFF
--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -3,20 +3,8 @@
 
 let
   copilotInstructionsFileName = "copilot-defaults.instructions.md";
-  copilotInstructionsText = ''
-    ---
-    description: "Use for every task. Persistent defaults for terminal commands, shell usage, and command logging. Prefer non-interactive commands and log command plus output to ~/.cache/copilot."
-    name: "Persistent Terminal Logging Defaults"
-    applyTo: "**"
-    ---
-    # Persistent Terminal Defaults
-
-    - Prefer non-interactive commands over interactive shells unless the task explicitly requires an interactive program.
-    - Minimize use of interactive terminal flows that can mangle command output in the IDE.
-    - When running terminal commands, also write the exact command and the resulting output to files under ~/.cache/copilot.
-    - Ensure ~/.cache/copilot exists before attempting to write logs there.
-    - Use append-safe logging or timestamped files so earlier command logs are not lost unless replacement is explicitly intended.
-  '';
+  copilotInstructionsPath = ./config/copilot/copilot-defaults.instructions.md;
+  copilotInstructionsText = builtins.readFile copilotInstructionsPath;
 in
 {
   nixpkgs.config = {

--- a/home-manager/config/copilot/copilot-defaults.instructions.md
+++ b/home-manager/config/copilot/copilot-defaults.instructions.md
@@ -1,0 +1,14 @@
+---
+description: "Use for every task. Persistent defaults for terminal commands, shell usage, and command logging. Prefer non-interactive commands and log command plus output to ~/.cache/copilot."
+name: "Persistent Terminal Logging Defaults"
+applyTo: "**"
+---
+# Persistent Terminal Defaults
+
+- Prefer non-interactive commands over interactive shells unless the task explicitly requires an interactive program.
+- Minimize use of interactive terminal flows that can mangle command output in the IDE.
+- When running terminal commands, also write the exact command and the resulting output to files under ~/.cache/copilot.
+- Ensure ~/.cache/copilot exists before attempting to write logs there.
+- Use append-safe logging or timestamped files so earlier command logs are not lost unless replacement is explicitly intended.
+- Do not use GitKraken MCP tools for private repositories.
+- For public repositories, prefer the git CLI and gh CLI over GitKraken MCP tools unless the user explicitly asks for GitKraken.


### PR DESCRIPTION
## Summary
- move the shared Copilot defaults into a tracked markdown file under home-manager/config/copilot
- have home-manager/common.nix read that file when generating per-platform VS Code prompt files
- keep the existing cross-workspace prompt installation behavior intact

## Validation
- task darwin-build HOST=ICFGG241C3Y03