### PR TITLE
Add JetBrains Copilot defaults

### DIFF
--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -4,7 +4,8 @@
 let
   copilotInstructionsFileName = "copilot-defaults.instructions.md";
   copilotInstructionsPath = ./config/copilot/copilot-defaults.instructions.md;
-  copilotInstructionsText = builtins.readFile copilotInstructionsPath;
+  githubCopilotConfigDir = ".config/github-copilot";
+  jetbrainsCopilotInstructionsFileName = "global-copilot-instructions.md";
 in
 {
   nixpkgs.config = {
@@ -22,12 +23,16 @@ in
   home.sessionPath = lib.mkBefore [ "$HOME/.local/bin" ];
 
   home.file = lib.mkMerge [
+    {
+      "${githubCopilotConfigDir}/${copilotInstructionsFileName}".source = copilotInstructionsPath;
+      "${githubCopilotConfigDir}/intellij/${jetbrainsCopilotInstructionsFileName}".source = copilotInstructionsPath;
+    }
     (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
-      "Library/Application Support/Code/User/prompts/${copilotInstructionsFileName}".text = copilotInstructionsText;
+      "Library/Application Support/Code/User/prompts/${copilotInstructionsFileName}".source = copilotInstructionsPath;
     })
     (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
-      ".config/Code/User/prompts/${copilotInstructionsFileName}".text = copilotInstructionsText;
-      ".vscode-server/data/User/prompts/${copilotInstructionsFileName}".text = copilotInstructionsText;
+      ".config/Code/User/prompts/${copilotInstructionsFileName}".source = copilotInstructionsPath;
+      ".vscode-server/data/User/prompts/${copilotInstructionsFileName}".source = copilotInstructionsPath;
     })
   ];
 

--- a/home-manager/config/copilot/copilot-defaults.instructions.md
+++ b/home-manager/config/copilot/copilot-defaults.instructions.md
@@ -10,5 +10,3 @@ applyTo: "**"
 - When running terminal commands, also write the exact command and the resulting output to files under ~/.cache/copilot.
 - Ensure ~/.cache/copilot exists before attempting to write logs there.
 - Use append-safe logging or timestamped files so earlier command logs are not lost unless replacement is explicitly intended.
-- Do not use GitKraken MCP tools for private repositories.
-- For public repositories, prefer the git CLI and gh CLI over GitKraken MCP tools unless the user explicitly asks for GitKraken.


### PR DESCRIPTION
## Summary
- add GitHub Copilot user config targets under ~/.config/github-copilot
- generate the JetBrains global Copilot instructions file from the tracked Home Manager source
- sync the tracked Copilot instructions file to the current live VS Code defaults

## Validation
- task darwin-build HOST=ICFGG241C3Y03