### PR TITLE
Fix Starship zsh init

### DIFF
--- a/home-manager/starship.nix
+++ b/home-manager/starship.nix
@@ -3,7 +3,7 @@
 {
   programs.starship = {
     enable = true;
-    enableZshIntegration = true;
+    enableZshIntegration = false;
     settings = {
       add_newline = true;
       command_timeout = 500;

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -40,6 +40,12 @@
       if command -v fzf >/dev/null 2>&1; then
         source <(fzf --zsh)
       fi
+
+      # Initialize Starship through PATH so shell startup does not depend on a
+      # hardcoded store or Homebrew path.
+      if [[ "$TERM" != "dumb" ]] && command -v starship >/dev/null 2>&1; then
+        eval "$(starship init zsh)"
+      fi
     '';
 
     shellAliases = {


### PR DESCRIPTION
## Summary
- disable Home Manager's built-in Zsh integration for Starship
- initialize Starship from PATH so shell startup does not depend on a stale absolute binary path
- keep prompt startup guarded for dumb terminals

## Testing
- task darwin-build HOST=ICFGG241C3Y03
- nix build '.#darwinConfigurations.ICFGG241C3Y03.config.home-manager.users."42245".home.activationPackage'
- ./result/activate
- zsh -lic 'command -v starship; grep -n "starship" ~/.zshrc | head -n 5'
