### PR TITLE
Add cross-platform Nix validation workflow

### DIFF
--- a/.github/workflows/nix-validation.yml
+++ b/.github/workflows/nix-validation.yml
@@ -1,0 +1,69 @@
+name: Nix Validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  flake-check:
+    name: Flake Check (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Run flake checks
+        run: nix flake check --print-build-logs
+
+  linux-and-wsl-builds:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux Host Build
+            build-command: nix build .#nixosConfigurations.krile.config.system.build.toplevel --print-build-logs
+          - name: WSL System Build
+            build-command: nix build .#nixosConfigurations.wsl.config.system.build.toplevel --print-build-logs
+          - name: WSL Home Manager Build
+            build-command: nix build '.#homeConfigurations."nixos@wsl".activationPackage' --print-build-logs
+          - name: Devcontainer Home Build
+            build-command: nix build '.#homeConfigurations."vscode@devcontainer".activationPackage' --print-build-logs
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build target
+        run: ${{ matrix.build-command }}
+
+  darwin-build:
+    name: Darwin Build
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build Darwin system
+        run: nix build .#darwinConfigurations.ICFGG241C3Y03.system --print-build-logs

--- a/.github/workflows/nix-validation.yml
+++ b/.github/workflows/nix-validation.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 
       - name: Enable Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
 
       - name: Run flake checks
         run: nix flake check --print-build-logs
@@ -31,39 +31,39 @@ jobs:
       matrix:
         include:
           - name: Linux Host Build
-            build-command: nix build .#nixosConfigurations.krile.config.system.build.toplevel --print-build-logs
+            build_command: nix build .#nixosConfigurations.krile.config.system.build.toplevel --print-build-logs
           - name: WSL System Build
-            build-command: nix build .#nixosConfigurations.wsl.config.system.build.toplevel --print-build-logs
+            build_command: nix build .#nixosConfigurations.wsl.config.system.build.toplevel --print-build-logs
           - name: WSL Home Manager Build
-            build-command: nix build '.#homeConfigurations."nixos@wsl".activationPackage' --print-build-logs
+            build_command: nix build '.#homeConfigurations."nixos@wsl".activationPackage' --print-build-logs
           - name: Devcontainer Home Build
-            build-command: nix build '.#homeConfigurations."vscode@devcontainer".activationPackage' --print-build-logs
+            build_command: nix build '.#homeConfigurations."vscode@devcontainer".activationPackage' --print-build-logs
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 
       - name: Enable Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
 
       - name: Build target
-        run: ${{ matrix.build-command }}
+        run: ${{ matrix.build_command }}
 
   darwin-build:
     name: Darwin Build
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 
       - name: Enable Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
 
       - name: Build Darwin system
         run: nix build .#darwinConfigurations.ICFGG241C3Y03.system --print-build-logs

--- a/README.md
+++ b/README.md
@@ -200,20 +200,12 @@ If migrating from the old monolithic configuration:
 3. Test the build with `task check` and `task build`
 4. Switch when ready with `task switch`
 
-## Known Issues (macOS)
+## macOS Notes
 
-### LLVM/Zig Build Failures (2025-01-12)
-
-Due to upstream issues with building LLVM 20 from source on macOS (failing `getMacOSHostVersion` test) and/or binary cache misses, the following packages have been temporarily disabled to avoid massive local compilation times and build failures:
-
-1. **Firefox**:
-   - `home-manager/home-darwin.nix`: Removed `firefox` / `firefox-bin`.
-   - `home-manager/common.nix`: Set `stylix.targets.firefox.enable = false`.
-
-2. **ncdu**:
-   - `home-manager/common.nix`: Commented out. Modern `ncdu` (v2+) is written in Zig, which pulls in the failing LLVM toolchain.
-
-**Fix:** Once LLVM 20 builds reliably on macOS or the cache is populated, these can be re-enabled.
+- Firefox is installed on macOS via Homebrew casks in `hosts/darwin/default.nix`.
+- The Stylix Firefox target remains disabled in `home-manager/home-darwin.nix`, so Firefox theming integration is intentionally off on macOS for now.
+- `ncdu` is not currently included in the shared package list in `home-manager/common.nix`.
+- The previous LLVM/Zig build warning from 2025 is no longer confirmed by current dry-run checks: on 2026-03-20, `nix build nixpkgs#ncdu --dry-run` resolved via fetchable artifacts, and `nix build nixpkgs#firefox --dry-run` resolved to fetched artifacts plus small wrapper derivations rather than the older large local toolchain build pattern.
 
 ## Validation Notes
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ If migrating from the old monolithic configuration:
 ## Known Issues (macOS)
 
 ### LLVM/Zig Build Failures (2025-01-12)
+
 Due to upstream issues with building LLVM 20 from source on macOS (failing `getMacOSHostVersion` test) and/or binary cache misses, the following packages have been temporarily disabled to avoid massive local compilation times and build failures:
 
 1. **Firefox**:
@@ -216,8 +217,15 @@ Due to upstream issues with building LLVM 20 from source on macOS (failing `getM
 
 ## Validation Notes
 
-### macOS
+### Darwin Validation
 
 - `darwin-rebuild` is expected to be available from the active system profile
 - Platform-aware tasks in `taskfile.yaml` detect Darwin and route to `darwin-rebuild`
 - Home Manager is integrated into the Darwin flake output rather than managed separately
+
+### GitHub Actions CI
+
+- GitHub Actions can validate Linux and macOS targets directly by building flake outputs.
+- The WSL target can be validated in CI by building `nixosConfigurations.wsl`, which checks the NixOS-WSL configuration itself.
+- GitHub-hosted runners do not provide a real WSL2 runtime session, so end-to-end WSL boot or runtime tests require a self-hosted Windows runner with WSL2 enabled.
+- The workflow for this repository lives at `.github/workflows/nix-validation.yml`.

--- a/home-manager/home-darwin.nix
+++ b/home-manager/home-darwin.nix
@@ -20,7 +20,7 @@ in
 
   # Darwin-specific Stylix targets (extending common.nix)
   stylix.targets = {
-    # Temporary disabled due to LLVM/Zig build issues causing build failures on macOS.
+    # Keep Firefox Stylix integration off on macOS for now; Firefox itself is installed via Homebrew.
     firefox.enable = false;
     kitty.enable = true;
     vscode.enable = true;


### PR DESCRIPTION
Adds cross-platform Nix validation in GitHub Actions for Linux, Darwin, and WSL build targets. Note: hosted runners can build the WSL target but cannot provide a real WSL2 runtime session; end-to-end WSL2 runtime coverage requires a self-hosted Windows runner with WSL2 enabled. Chore: validate whether the Known Issues (macOS) section in README.md is still current, especially the temporary Firefox and ncdu notes.