### PR TITLE
chore: stabilize darwin upgrade and shared tooling defaults

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,3 +9,9 @@
 - Do not use GitKraken MCP tools for private repositories.
 - For public repositories, prefer the git CLI and gh CLI over GitKraken MCP tools unless the user explicitly asks for GitKraken.
 - Do not merge the current branch into any target or base branch unless the user explicitly instructs you to perform that merge.
+
+# Shared Tooling Defaults
+
+- The shared package set in `home-manager/common.nix` usually provides these CLI tools on managed hosts: git, gh, curl, wget, go-task (`task`), python3, pipx, maven, awscli2, awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose, overmind, bat, eza, fzf, fd, ripgrep (`rg`), sd, jq, yq-go (`yq`), zoxide, direnv, dasel, tmux, unzip, age, alejandra, ncdu, statix, deadnix, nixd, unison, glow, gum, tealdeer, file, which, tree, and rsync.
+- Prefer these repo-managed tools over generic fallbacks when they fit the task: `rg` over `grep`, `fd` over `find`, `jq`/`yq`/`dasel` for structured data, `task` for repository workflows, and `alejandra`/`statix`/`deadnix` for Nix formatting and linting.
+- Treat this tool list as the default expected environment for repo work, but verify availability with `command -v` when portability matters because `home-manager/common.nix` still filters packages by host support.

--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773963144,
-        "narHash": "sha256-WzBOBfSay3GYilUfKaUa1Mbf8/jtuAiJIedx7fWuIX4=",
+        "lastModified": 1774274588,
+        "narHash": "sha256-dnHvv5EMUgTzGZmA+3diYjQU2O6BEpGLEOgJ1Qe9LaY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a91b3ea73a765614d90360580b689c48102d1d33",
+        "rev": "cf9686ba26f5ef788226843bc31fda4cf72e373b",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773814637,
-        "narHash": "sha256-GNU+ooRmrHLfjlMsKdn0prEKVa0faVanm0jrgu1J/gY=",
+        "lastModified": 1774244481,
+        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fea3b367d61c1a6592bc47c72f40a9f3e6a53e96",
+        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1773790548,
-        "narHash": "sha256-6lI+ZM1yWL4cNRT39s8AUC+kwq237PZCrWc1ubLOwqc=",
+        "lastModified": 1774194089,
+        "narHash": "sha256-SCczWhr8y8aaXVHG+gOGcRahNb0BU1Z5zYZuv9W/nA8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e8ffdddd42062ebc90178db9d013aa38c20b7b2f",
+        "rev": "7c34241d80ea64dd2039bb3a786fb66b4c6261d9",
         "type": "github"
       },
       "original": {

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -44,6 +44,13 @@
     dontCheckRuntimeDeps = true;
     pythonRelaxDeps = (old.pythonRelaxDeps or []) ++ ["click"];
   });
+  direnvPatched =
+    if pkgs.stdenv.isDarwin
+    then
+      pkgs.direnv.overrideAttrs (old: {
+        env = (old.env or {}) // {CGO_ENABLED = "1";};
+      })
+    else pkgs.direnv;
   commonPackages = with pkgs; [
     # Development tools
     git
@@ -77,7 +84,7 @@
     jq
     yq-go
     zoxide
-    direnv
+    direnvPatched
     dasel
     tmux
     unzip
@@ -248,6 +255,7 @@ in {
     direnv = {
       enable = true;
       enableZshIntegration = true;
+      package = direnvPatched;
     };
 
     home-manager.enable = true;

--- a/home-manager/config/copilot/copilot-defaults.instructions.md
+++ b/home-manager/config/copilot/copilot-defaults.instructions.md
@@ -15,3 +15,9 @@ applyTo: "**"
 - Do not use GitKraken MCP tools for private repositories.
 - For public repositories, prefer the git CLI and gh CLI over GitKraken MCP tools unless the user explicitly asks for GitKraken.
 - Do not merge the current branch into any target or base branch unless the user explicitly instructs you to perform that merge.
+
+# Shared Tooling Defaults
+
+- The shared package set in home-manager/common.nix usually provides these CLI tools on managed hosts: git, gh, curl, wget, go-task (`task`), python3, pipx, maven, awscli2, awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose, overmind, bat, eza, fzf, fd, ripgrep (`rg`), sd, jq, yq-go (`yq`), zoxide, direnv, dasel, tmux, unzip, age, alejandra, ncdu, statix, deadnix, nixd, unison, glow, gum, tealdeer, file, which, tree, and rsync.
+- Prefer these repo-managed tools over generic fallbacks when they fit the task: `rg` over `grep`, `fd` over `find`, `jq`/`yq`/`dasel` for structured data, `task` for repository workflows, and `alejandra`/`statix`/`deadnix` for Nix formatting and linting.
+- Treat this tool list as the default expected environment for repo work, but verify availability with `command -v` when portability matters because home-manager/common.nix still filters packages by host support.

--- a/home-manager/home-darwin.nix
+++ b/home-manager/home-darwin.nix
@@ -22,27 +22,83 @@ in {
     # Darwin-specific packages
     packages = darwinPackages;
 
-    # Install SDKMAN! on macOS so Java toolchains can be managed declaratively
-    activation.installSdkman = lib.hm.dag.entryAfter ["writeBoundary"] ''
-      sdkman_dir="$HOME/.sdkman"
-      if [ ! -s "$sdkman_dir/bin/sdkman-init.sh" ]; then
-        echo "Installing SDKMAN! into $sdkman_dir"
-        tmp_home="$(${pkgs.coreutils}/bin/mktemp -d)"
-        cleanup() {
-          ${pkgs.coreutils}/bin/rm -rf "$tmp_home"
-        }
-        trap cleanup EXIT INT TERM
-        install_env_path="${pkgs.unzip}/bin:${pkgs.zip}/bin:${pkgs.gnutar}/bin:${pkgs.curl}/bin:${pkgs.coreutils}/bin:${pkgs.gnused}/bin:${pkgs.gawk}/bin:$PATH"
-        env PATH="$install_env_path" HOME="$tmp_home" ZDOTDIR="$tmp_home" SDKMAN_DIR="$sdkman_dir" \
-          ${pkgs.curl}/bin/curl -sSf "https://get.sdkman.io?rcupdate=false" -o "$tmp_home/install-sdkman.sh"
-        env PATH="$install_env_path" HOME="$tmp_home" ZDOTDIR="$tmp_home" SDKMAN_DIR="$sdkman_dir" \
-          ${pkgs.bash}/bin/bash "$tmp_home/install-sdkman.sh"
-        cleanup
-        trap - EXIT INT TERM
-      else
-        echo "SDKMAN! already present"
-      fi
-    '';
+    activation = {
+      # Install SDKMAN! on macOS so Java toolchains can be managed declaratively
+      installSdkman = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        sdkman_dir="$HOME/.sdkman"
+        if [ ! -s "$sdkman_dir/bin/sdkman-init.sh" ]; then
+          echo "Installing SDKMAN! into $sdkman_dir"
+          tmp_home="$(${pkgs.coreutils}/bin/mktemp -d)"
+          cleanup() {
+            ${pkgs.coreutils}/bin/rm -rf "$tmp_home"
+          }
+          trap cleanup EXIT INT TERM
+          install_env_path="${pkgs.unzip}/bin:${pkgs.zip}/bin:${pkgs.gnutar}/bin:${pkgs.curl}/bin:${pkgs.coreutils}/bin:${pkgs.gnused}/bin:${pkgs.gawk}/bin:$PATH"
+          env PATH="$install_env_path" HOME="$tmp_home" ZDOTDIR="$tmp_home" SDKMAN_DIR="$sdkman_dir" \
+            ${pkgs.curl}/bin/curl -sSf "https://get.sdkman.io?rcupdate=false" -o "$tmp_home/install-sdkman.sh"
+          env PATH="$install_env_path" HOME="$tmp_home" ZDOTDIR="$tmp_home" SDKMAN_DIR="$sdkman_dir" \
+            ${pkgs.bash}/bin/bash "$tmp_home/install-sdkman.sh"
+          cleanup
+          trap - EXIT INT TERM
+        else
+          echo "SDKMAN! already present"
+        fi
+      '';
+
+      # Keep Node.js off Homebrew on macOS; install the latest release through nvm instead.
+      installNvmNode = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        install_env_path="${pkgs.curl}/bin:${pkgs.wget}/bin:${pkgs.coreutils}/bin:${pkgs.gawk}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+        export PATH="$install_env_path"
+        export TERM=dumb
+        export NVM_DIR="$HOME/.nvm"
+        mkdir -p "$NVM_DIR"
+
+        if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
+          set +u
+          . "/opt/homebrew/opt/nvm/nvm.sh"
+          export NVM_SYMLINK_CURRENT=true
+          nvm install node >/dev/null
+          nvm alias default node >/dev/null
+          nvm use default >/dev/null
+          set -u
+        else
+          echo "Homebrew nvm is not installed; skipping Node.js installation"
+        fi
+      '';
+
+      installConfluenceCli = lib.hm.dag.entryAfter ["installNvmNode"] ''
+        install_env_path="${pkgs.curl}/bin:${pkgs.wget}/bin:${pkgs.coreutils}/bin:${pkgs.gawk}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:${pkgs.jq}/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+        export PATH="$install_env_path"
+        export TERM=dumb
+        export NVM_DIR="$HOME/.nvm"
+
+        if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
+          set +u
+          . "/opt/homebrew/opt/nvm/nvm.sh"
+          export NVM_SYMLINK_CURRENT=true
+          if nvm use default >/dev/null 2>&1; then
+            current_version="$(${pkgs.coreutils}/bin/timeout 30s bash -lc 'npm list -g confluence-cli --depth=0 --json 2>/dev/null || true' | ${pkgs.jq}/bin/jq -r '.dependencies["confluence-cli"].version // empty' 2>/dev/null || true)"
+            latest_version="$(${pkgs.coreutils}/bin/timeout 30s npm view confluence-cli version 2>/dev/null || true)"
+
+            if [ -z "$latest_version" ]; then
+              echo "Unable to resolve latest confluence-cli version; leaving current install unchanged"
+            elif [ "$current_version" != "$latest_version" ]; then
+              echo "Installing confluence-cli $latest_version via npm"
+              if ! npm install -g "confluence-cli@$latest_version" >/dev/null 2>&1; then
+                echo "npm install for confluence-cli failed; leaving current install unchanged"
+              fi
+            else
+              echo "confluence-cli $current_version already installed"
+            fi
+          else
+            echo "nvm default Node is unavailable; skipping confluence-cli installation"
+          fi
+          set -u
+        else
+          echo "Homebrew nvm is not installed; skipping confluence-cli installation"
+        fi
+      '';
+    };
 
     # Install the shared Copilot defaults into the macOS VS Code user prompts directory.
     file."Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md".source = ./config/copilot/copilot-defaults.instructions.md;
@@ -84,11 +140,11 @@ in {
       fi
 
       export NVM_DIR="$HOME/.nvm"
-      if [ -s "$NVM_DIR/nvm.sh" ]; then
-        source "$NVM_DIR/nvm.sh"
+      if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
+        source "/opt/homebrew/opt/nvm/nvm.sh"
       fi
-      if [ -s "$NVM_DIR/bash_completion" ]; then
-        source "$NVM_DIR/bash_completion"
+      if [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ]; then
+        source "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
       fi
       export NVM_SYMLINK_CURRENT=true
       if command -v nvm >/dev/null 2>&1; then

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -204,7 +204,6 @@
     taps = [
       "kionsoftware/tap"
       "atlassian/homebrew-acli"
-      "pchuri/tap"
     ];
 
     # CLI tools and libraries
@@ -212,7 +211,6 @@
       "acli"
       "aws-console"
       "colima"
-      "pchuri/tap/confluence-cli"
       "docker-credential-helper"
       "jira-cli"
       "kion-cli"


### PR DESCRIPTION
## Summary

This PR updates the flake inputs and fixes the Darwin upgrade path so `task upgrade` succeeds after the input refresh.

## Changes

- update `flake.lock` for `nixpkgs`, `home-manager`, and `stylix`
- patch Darwin `direnv` usage to avoid the nixpkgs `direnv 2.37.1` cgo/linker build failure
- switch macOS Node management to Homebrew `nvm` plus `nvm`-installed Node instead of relying on Homebrew-managed Node
- harden Darwin Home Manager activation for `nvm` by providing the required tool paths, safe `TERM`, and `nounset` handling
- remove Homebrew management of `pchuri/tap/confluence-cli` so it does not pull Homebrew `node`
- install/update `confluence-cli` through npm under the `nvm`-managed Node environment, with best-effort activation behavior
- add shared tooling defaults to the Copilot instruction files so agents know which common repo-managed tools are typically available from `home-manager/common.nix`

## Validation

- `task fmt:check`
- `darwin-rebuild build --flake .#darwin`
- `task upgrade`
