### PR TITLE
Update browser defaults and Copilot guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,13 +2,17 @@
 
 - Prefer non-interactive commands over interactive shells unless the task explicitly requires an interactive program.
 - Minimize use of interactive terminal flows that can mangle command output in the IDE.
+- Prefer an isolated shell for long, heavily quoted, or stateful commands. Use a fresh terminal session instead of the shared shell when the command includes complex quoting, regexes, JSON, plist data, `osascript`, `jq`, `nix eval --expr`, or several chained steps.
+- If a shared shell shows prompt fragments, reused partial commands, or quote mangling, stop reusing it and rerun the workflow from an isolated shell.
 - When running terminal commands, also write the exact command and the resulting output to files under `~/.cache/copilot`.
 - Ensure `~/.cache/copilot` exists before attempting to write logs there.
-- Prefer executing scripts from files written under `~/.cache/copilot` instead of inline heredocs when a command needs multi-line shell logic.
+- For multi-line shell logic or long text payloads, write a temporary script or data file under `~/.cache/copilot` and execute it from an isolated shell instead of embedding long inline commands or heredocs.
+- Prefer file-editing tools for long text whenever possible; reserve shell text construction for short, stable snippets.
 - Use append-safe logging or timestamped files so earlier command logs are not lost unless replacement is explicitly intended.
 - When investigating tool or command failures, inspect relevant logs under `~/.cache/copilot` first; use prior successful executions there as concrete examples before retrying or changing approach.
-- Do not use GitKraken MCP tools for private repositories.
-- For public repositories, prefer the git CLI and gh CLI over GitKraken MCP tools unless the user explicitly asks for GitKraken.
+- For GitHub repository, issue, release, and pull request operations, prefer GitHub's official MCP server when it is available.
+- Do not use GitKraken MCP tools for either private or public repositories.
+- When GitHub's official MCP server is unavailable, prefer the git CLI and gh CLI over other repository MCP integrations.
 - Do not merge the current branch into any target or base branch unless the user explicitly instructs you to perform that merge.
 
 # Shared Tooling Defaults

--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774274588,
-        "narHash": "sha256-dnHvv5EMUgTzGZmA+3diYjQU2O6BEpGLEOgJ1Qe9LaY=",
+        "lastModified": 1774875830,
+        "narHash": "sha256-WPYlTmZvVa9dWlAziFkVjBdv1Z6giNIq40O1DxsBmiI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cf9686ba26f5ef788226843bc31fda4cf72e373b",
+        "rev": "7afd8cebb99e25a64a745765920e663478eb8830",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774244481,
-        "narHash": "sha256-4XfMXU0DjN83o6HWZoKG9PegCvKvIhNUnRUI19vzTcQ=",
+        "lastModified": 1774799055,
+        "narHash": "sha256-Tsq9BCz0q47ej1uFF39m4tuhcwru/ls6vCCJzutEpaw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4590696c8693fea477850fe379a01544293ca4e2",
+        "rev": "107cba9eb4a8d8c9f8e9e61266d78d340867913a",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772361940,
-        "narHash": "sha256-B1Cz+ydL1iaOnGlwOFld/C8lBECPtzhiy/pP93/CuyY=",
+        "lastModified": 1774915545,
+        "narHash": "sha256-COT4l/+ZddGBvrDVfPf7MEOJxV8EDKame6/aRnNIKcY=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "a4b33606111c9c5dcd10009042bb710307174f51",
+        "rev": "f3177b3c69fb3f03201098d7fe8ab6422cce7fc1",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1774194089,
-        "narHash": "sha256-SCczWhr8y8aaXVHG+gOGcRahNb0BU1Z5zYZuv9W/nA8=",
+        "lastModified": 1774897901,
+        "narHash": "sha256-GrSM/fvl4jhF39fjkI4oDMk4mR0mY+HHPY2ySWqAihQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7c34241d80ea64dd2039bb3a786fb66b4c6261d9",
+        "rev": "c09faedbde9cbda2aaace349c1e227d322972f54",
         "type": "github"
       },
       "original": {

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -34,6 +34,7 @@
     };
     "files.trimTrailingWhitespace" = true;
     "files.insertFinalNewline" = true;
+    "chat.mcp.gallery.enabled" = true;
     "git.autofetch" = true;
   };
   awsSamCliPatched = pkgs.aws-sam-cli.overridePythonAttrs (old: {

--- a/home-manager/config/copilot/copilot-defaults.instructions.md
+++ b/home-manager/config/copilot/copilot-defaults.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: "Use for every task. Persistent defaults for terminal commands, shell usage, and command logging. Prefer non-interactive commands and log command plus output to ~/.cache/copilot."
+description: "Use for every task. Persistent defaults for terminal commands, shell usage, isolated shells for long or heavily quoted commands, and command logging to ~/.cache/copilot."
 name: "Persistent Terminal Logging Defaults"
 applyTo: "**"
 ---
@@ -8,13 +8,17 @@ applyTo: "**"
 
 - Prefer non-interactive commands over interactive shells unless the task explicitly requires an interactive program.
 - Minimize use of interactive terminal flows that can mangle command output in the IDE.
+- Prefer an isolated shell for long, heavily quoted, or stateful commands. Use a fresh terminal session instead of the shared shell when the command includes complex quoting, regexes, JSON, plist data, `osascript`, `jq`, `nix eval --expr`, or several chained steps.
+- If a shared shell shows prompt fragments, reused partial commands, or quote mangling, stop reusing it and rerun the workflow from an isolated shell.
 - When running terminal commands, also write the exact command and the resulting output to files under ~/.cache/copilot.
 - Ensure ~/.cache/copilot exists before attempting to write logs there.
-- Prefer executing scripts from files written under ~/.cache/copilot instead of inline heredocs when a command needs multi-line shell logic.
+- For multi-line shell logic or long text payloads, write a temporary script or data file under ~/.cache/copilot and execute it from an isolated shell instead of embedding long inline commands or heredocs.
+- Prefer file-editing tools for long text whenever possible; reserve shell text construction for short, stable snippets.
 - Use append-safe logging or timestamped files so earlier command logs are not lost unless replacement is explicitly intended.
 - When investigating tool or command failures, inspect relevant logs under ~/.cache/copilot first; use prior successful executions there as concrete examples before retrying or changing approach.
-- Do not use GitKraken MCP tools for private repositories.
-- For public repositories, prefer the git CLI and gh CLI over GitKraken MCP tools unless the user explicitly asks for GitKraken.
+- For GitHub repository, issue, release, and pull request operations, prefer GitHub's official MCP server when it is available.
+- Do not use GitKraken MCP tools for either private or public repositories.
+- When GitHub's official MCP server is unavailable, prefer the git CLI and gh CLI over other repository MCP integrations.
 - Do not merge the current branch into any target or base branch unless the user explicitly instructs you to perform that merge.
 
 # Shared Tooling Defaults

--- a/home-manager/home-darwin.nix
+++ b/home-manager/home-darwin.nix
@@ -3,9 +3,13 @@
   lib,
   ...
 }: let
+  vivaldiBrowserWrapper = pkgs.writeShellScriptBin "vivaldi" ''
+    exec /usr/bin/open -a "Vivaldi" "$@"
+  '';
   availableOnHost = pkg: lib.meta.availableOn pkgs.stdenv.hostPlatform pkg;
   darwinPackages = lib.filter availableOnHost (with pkgs; [
     mas
+    vivaldiBrowserWrapper
   ]);
 in {
   _module.args.isWsl = lib.mkDefault false;
@@ -21,6 +25,7 @@ in {
 
     # Darwin-specific packages
     packages = darwinPackages;
+    sessionVariables.BROWSER = "vivaldi";
 
     activation = {
       # Install SDKMAN! on macOS so Java toolchains can be managed declaratively
@@ -96,6 +101,16 @@ in {
           set -u
         else
           echo "Homebrew nvm is not installed; skipping confluence-cli installation"
+        fi
+      '';
+
+      setDefaultBrowser = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        if [ -d "/Applications/Vivaldi.app" ]; then
+          ${pkgs.duti}/bin/duti -s com.vivaldi.Vivaldi http all
+          ${pkgs.duti}/bin/duti -s com.vivaldi.Vivaldi https all
+          ${pkgs.duti}/bin/duti -s com.vivaldi.Vivaldi public.xhtml all
+        else
+          echo "Skipping Vivaldi default browser registration: /Applications/Vivaldi.app is unavailable."
         fi
       '';
     };

--- a/home-manager/home-wsl.nix
+++ b/home-manager/home-wsl.nix
@@ -44,6 +44,43 @@
     dbus
     nerd-fonts.fira-code
   ];
+  vivaldiBrowserWrapper = pkgs.writeShellApplication {
+    name = "vivaldi";
+    runtimeInputs = [pkgs.coreutils];
+    text = ''
+      set -eu
+
+      windows_powershell_exe="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+      wslpath_exe="/sbin/wslpath"
+      vivaldi_exe=""
+
+      if [ -x "$windows_powershell_exe" ] && [ -x "$wslpath_exe" ]; then
+        windows_local_appdata_win="$($windows_powershell_exe -NoProfile -Command "[Environment]::GetFolderPath('LocalApplicationData')" | tr -d '\r')"
+        if [ -n "$windows_local_appdata_win" ]; then
+          windows_local_appdata_unix="$($wslpath_exe -u "$windows_local_appdata_win")"
+          candidate="$windows_local_appdata_unix/Vivaldi/Application/vivaldi.exe"
+          if [ -f "$candidate" ]; then
+            vivaldi_exe="$candidate"
+          fi
+        fi
+      fi
+
+      if [ -z "$vivaldi_exe" ] && [ -f "/mnt/c/Program Files/Vivaldi/Application/vivaldi.exe" ]; then
+        vivaldi_exe="/mnt/c/Program Files/Vivaldi/Application/vivaldi.exe"
+      fi
+
+      if [ -z "$vivaldi_exe" ] && [ -f "/mnt/c/Program Files (x86)/Vivaldi/Application/vivaldi.exe" ]; then
+        vivaldi_exe="/mnt/c/Program Files (x86)/Vivaldi/Application/vivaldi.exe"
+      fi
+
+      if [ -z "$vivaldi_exe" ]; then
+        echo "Vivaldi is not installed on the Windows host." >&2
+        exit 1
+      fi
+
+      exec "$vivaldi_exe" "$@"
+    '';
+  };
 
   availableOnHost = pkg: lib.meta.availableOn pkgs.stdenv.hostPlatform pkg;
   availableLinuxPackages = lib.filter availableOnHost linuxPackages;
@@ -65,6 +102,7 @@
     "nix.formatterPath" = "alejandra";
     "files.trimTrailingWhitespace" = true;
     "files.insertFinalNewline" = true;
+    "chat.mcp.gallery.enabled" = true;
     "git.autofetch" = true;
   };
 in {
@@ -79,7 +117,8 @@ in {
     username = lib.mkDefault "nixos";
     homeDirectory = lib.mkDefault "/home/nixos";
 
-    packages = availableLinuxPackages;
+    packages = availableLinuxPackages ++ [vivaldiBrowserWrapper];
+    sessionVariables.BROWSER = "vivaldi";
 
     activation.dconfSettings = lib.mkForce (
       lib.hm.dag.entryAfter ["checkLinkTargets"] ''

--- a/home-manager/profiles/desktop-linux.nix
+++ b/home-manager/profiles/desktop-linux.nix
@@ -4,9 +4,11 @@
   lib,
   ...
 }: let
+  browserDesktopId = "vivaldi.desktop";
   desktopPackages = with pkgs; [
     # Web browsers
     firefox
+    vivaldi
 
     # Media
     vlc
@@ -33,9 +35,40 @@
 in {
   # Desktop applications
   home.packages = availablePackages;
+  home.sessionVariables.BROWSER = "vivaldi";
 
   # Note: System monitoring tools (htop, btop, iotop) moved to platform-specific configs
   # Note: Removed duplicated discord entry
+
+  xdg = {
+    desktopEntries.vivaldi = {
+      name = "Vivaldi";
+      genericName = "Web Browser";
+      exec = "${pkgs.vivaldi}/bin/vivaldi %U";
+      terminal = false;
+      categories = ["Network" "WebBrowser"];
+      mimeType = [
+        "application/xhtml+xml"
+        "text/html"
+        "x-scheme-handler/about"
+        "x-scheme-handler/http"
+        "x-scheme-handler/https"
+        "x-scheme-handler/unknown"
+      ];
+    };
+
+    mimeApps = {
+      enable = true;
+      defaultApplications = {
+        "application/xhtml+xml" = [browserDesktopId];
+        "text/html" = [browserDesktopId];
+        "x-scheme-handler/about" = [browserDesktopId];
+        "x-scheme-handler/http" = [browserDesktopId];
+        "x-scheme-handler/https" = [browserDesktopId];
+        "x-scheme-handler/unknown" = [browserDesktopId];
+      };
+    };
+  };
 
   # Firefox configuration
   programs.firefox = {

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -249,7 +249,8 @@
     masApps = {
       # Mac App Store applications (find IDs with: mas search "app name")
       "Xcode" = 497799835;
-      "Amazon Kindle" = 302584613;
+      # Kindle upgrades are currently failing via `mas` with MASError 5 on this host.
+      # Keep it out of automated brew bundle runs so Darwin upgrades stay reliable.
       "Unzip - RAR ZIP 7Z Unarchiver" = 1537056818;
     };
   };


### PR DESCRIPTION
## Summary

- refresh the flake inputs to newer locked revisions
- enable the VS Code MCP gallery setting in shared user settings
- set Vivaldi as the default browser where the repo can manage it
- update the default Copilot guidance to prefer isolated shells and GitHub's official MCP server
- stop macOS upgrades from failing on the Kindle App Store update path

## Detailed Changes

- `home-manager/common.nix` enables `chat.mcp.gallery.enabled` in the shared VS Code user settings.
- `home-manager/config/copilot/copilot-defaults.instructions.md` and `.github/copilot-instructions.md` now prefer isolated shells for long or heavily quoted commands, recommend temporary script/data files under `~/.cache/copilot` instead of inline heredocs for long payloads, prefer GitHub's official MCP server when available, and explicitly avoid GitKraken MCP for both public and private repositories.
- `home-manager/profiles/desktop-linux.nix` installs Vivaldi, exports `BROWSER=vivaldi`, and sets the desktop/XDG default applications for HTTP, HTTPS, HTML, XHTML, and related browser MIME handlers to `vivaldi.desktop`.
- `home-manager/home-wsl.nix` adds a `vivaldi` wrapper that launches the Windows Vivaldi install from WSL, exports `BROWSER=vivaldi`, and enables the MCP gallery in the WSL VS Code settings payload.
- `home-manager/home-darwin.nix` adds a Vivaldi launcher wrapper, exports `BROWSER=vivaldi`, and registers supported macOS browser handlers via `duti` during Home Manager activation.
- `hosts/darwin/default.nix` removes Amazon Kindle from `masApps` so `darwin-rebuild switch` no longer fails on the current `mas` download error for Kindle.
- `flake.lock` refreshes the pinned `home-manager`, `nixpkgs`, `plasma-manager`, and `stylix` inputs.

## Notes

- On this macOS host, `duti -s com.vivaldi.Vivaldi public.html all` fails with Launch Services error `-54`, so the activation hook intentionally limits registration to the handlers that succeed and keep `task switch` reliable.

## Validation

- `task fmt:check`
- `task lint:nix`
- `task darwin-build HOST=darwin`
- `task switch`
- `nix eval --impure --raw .#homeConfigurations."nixos@wsl".config.home.sessionVariables.BROWSER`
- `nix eval --impure --raw .#homeConfigurations."vscode@devcontainer".config.home.sessionVariables.BROWSER`