### PR TITLE
Fix Darwin Flameshot hotkeys and browser defaults

### DIFF
--- a/home-manager/config/flameshot/flameshot.ini
+++ b/home-manager/config/flameshot/flameshot.ini
@@ -1,0 +1,9 @@
+[General]
+contrastOpacity=188
+saveAfterCopy=true
+startupLaunch=true
+useJpgForClipboard=true
+
+[Shortcuts]
+SCREENSHOT_HISTORY=Ctrl+Shift+3
+TAKE_SCREENSHOT=Ctrl+Shift+4

--- a/home-manager/home-darwin.nix
+++ b/home-manager/home-darwin.nix
@@ -6,6 +6,118 @@
   vivaldiBrowserWrapper = pkgs.writeShellScriptBin "vivaldi" ''
     exec /usr/bin/open -a "Vivaldi" "$@"
   '';
+  setDefaultBrowserSource = pkgs.writeText "set-default-browser.c" ''
+    #include <CoreFoundation/CoreFoundation.h>
+    #include <CoreServices/CoreServices.h>
+    #include <stdbool.h>
+    #include <stdio.h>
+    #include <stdlib.h>
+
+    static bool cfstring_equals_case_insensitive(CFStringRef left, CFStringRef right) {
+      return left != NULL && right != NULL && CFStringCompare(left, right, kCFCompareCaseInsensitive) == kCFCompareEqualTo;
+    }
+
+    static bool default_handler_for_url_scheme_matches(const char *scheme, CFStringRef bundle_identifier) {
+      CFStringRef scheme_ref = CFStringCreateWithCString(kCFAllocatorDefault, scheme, kCFStringEncodingUTF8);
+      if (scheme_ref == NULL) {
+        return false;
+      }
+
+      CFStringRef current_handler = LSCopyDefaultHandlerForURLScheme(scheme_ref);
+      CFRelease(scheme_ref);
+
+      bool matches = cfstring_equals_case_insensitive(current_handler, bundle_identifier);
+      if (current_handler != NULL) {
+        CFRelease(current_handler);
+      }
+
+      return matches;
+    }
+
+    static bool default_handler_for_content_type_matches(const char *content_type, LSRolesMask role, CFStringRef bundle_identifier) {
+      CFStringRef content_type_ref = CFStringCreateWithCString(kCFAllocatorDefault, content_type, kCFStringEncodingUTF8);
+      if (content_type_ref == NULL) {
+        return false;
+      }
+
+      CFStringRef current_handler = LSCopyDefaultRoleHandlerForContentType(content_type_ref, role);
+      CFRelease(content_type_ref);
+
+      bool matches = cfstring_equals_case_insensitive(current_handler, bundle_identifier);
+      if (current_handler != NULL) {
+        CFRelease(current_handler);
+      }
+
+      return matches;
+    }
+
+    static bool set_default_handler_for_url_scheme(const char *scheme, CFStringRef bundle_identifier) {
+      if (default_handler_for_url_scheme_matches(scheme, bundle_identifier)) {
+        return true;
+      }
+
+      CFStringRef scheme_ref = CFStringCreateWithCString(kCFAllocatorDefault, scheme, kCFStringEncodingUTF8);
+      if (scheme_ref == NULL) {
+        fprintf(stderr, "set-default-browser: could not create CFString for URL scheme '%s'\n", scheme);
+        return false;
+      }
+
+      OSStatus status = LSSetDefaultHandlerForURLScheme(scheme_ref, bundle_identifier);
+      CFRelease(scheme_ref);
+      if (status != noErr) {
+        fprintf(stderr, "set-default-browser: failed to set handler for URL scheme '%s' (error %d)\n", scheme, (int)status);
+        return false;
+      }
+
+      return true;
+    }
+
+    static bool set_default_handler_for_content_type(const char *content_type, LSRolesMask role, CFStringRef bundle_identifier) {
+      if (default_handler_for_content_type_matches(content_type, role, bundle_identifier)) {
+        return true;
+      }
+
+      CFStringRef content_type_ref = CFStringCreateWithCString(kCFAllocatorDefault, content_type, kCFStringEncodingUTF8);
+      if (content_type_ref == NULL) {
+        fprintf(stderr, "set-default-browser: could not create CFString for content type '%s'\n", content_type);
+        return false;
+      }
+
+      OSStatus status = LSSetDefaultRoleHandlerForContentType(content_type_ref, role, bundle_identifier);
+      CFRelease(content_type_ref);
+      if (status != noErr) {
+        fprintf(stderr, "set-default-browser: failed to set handler for content type '%s' (error %d)\n", content_type, (int)status);
+        return false;
+      }
+
+      return true;
+    }
+
+    int main(int argc, char *argv[]) {
+      if (argc != 2) {
+        fprintf(stderr, "usage: %s <bundle-identifier>\n", argv[0]);
+        return 64;
+      }
+
+      CFStringRef bundle_identifier = CFStringCreateWithCString(kCFAllocatorDefault, argv[1], kCFStringEncodingUTF8);
+      if (bundle_identifier == NULL) {
+        fprintf(stderr, "set-default-browser: could not create CFString for bundle identifier '%s'\n", argv[1]);
+        return 1;
+      }
+
+      bool success = true;
+      success = set_default_handler_for_url_scheme("http", bundle_identifier) && success;
+      success = set_default_handler_for_url_scheme("https", bundle_identifier) && success;
+      success = set_default_handler_for_content_type("public.xhtml", kLSRolesAll, bundle_identifier) && success;
+
+      CFRelease(bundle_identifier);
+      return success ? 0 : 1;
+    }
+  '';
+  setDefaultBrowser = pkgs.runCommandCC "set-default-browser" {} ''
+    mkdir -p "$out/bin"
+    "$CC" -Wall -Wextra -O2 -o "$out/bin/set-default-browser" ${setDefaultBrowserSource} -framework CoreServices -framework CoreFoundation
+  '';
   availableOnHost = pkg: lib.meta.availableOn pkgs.stdenv.hostPlatform pkg;
   darwinPackages = lib.filter availableOnHost (with pkgs; [
     mas
@@ -101,9 +213,9 @@ in {
 
       setDefaultBrowser = lib.hm.dag.entryAfter ["writeBoundary"] ''
         if [ -d "/Applications/Vivaldi.app" ]; then
-          ${pkgs.duti}/bin/duti -s com.vivaldi.Vivaldi http all
-          ${pkgs.duti}/bin/duti -s com.vivaldi.Vivaldi https all
-          ${pkgs.duti}/bin/duti -s com.vivaldi.Vivaldi public.xhtml all
+          if ! ${setDefaultBrowser}/bin/set-default-browser com.vivaldi.Vivaldi; then
+            echo "Warning: failed to register Vivaldi as the default browser; leaving existing LaunchServices handlers unchanged"
+          fi
         else
           echo "Skipping Vivaldi default browser registration: /Applications/Vivaldi.app is unavailable."
         fi
@@ -177,6 +289,7 @@ in {
     # Extensions and other VSCode config can be added here
     # Stylix will automatically handle theming
   };
+  xdg.configFile."flameshot/flameshot.ini".source = ./config/flameshot/flameshot.ini;
   # Kitty terminal configuration
   xdg.configFile."kitty/kitty.conf".source = ./config/kitty/kitty.conf;
 }

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -105,7 +105,11 @@
       };
 
       CustomUserPreferences = {
-        # Disable macOS default capture shortcuts so Flameshot can override them
+        # Disable macOS default capture shortcuts so Flameshot can claim the
+        # native chords it supports on macOS. Flameshot exposes global actions
+        # for Cmd+Shift+4 and Cmd+Shift+3; the clipboard variants remain
+        # disabled because Flameshot does not provide native macOS global
+        # bindings for them.
         "com.apple.symbolichotkeys" = {
           AppleSymbolicHotKeys = {
             # Cmd + Shift + 4 (Rectangular capture)
@@ -161,15 +165,13 @@
   # The platform the configuration will be used on.
   nixpkgs.hostPlatform = "aarch64-darwin";
 
-  # Set up skhd for custom hotkeys (like Flameshot)
-  services.skhd = {
-    enable = true;
-    skhdConfig = ''
-      # Rectangular capture
-      shift + cmd - 4 : /Applications/Flameshot.app/Contents/MacOS/flameshot gui
-      # Full screen capture
-      shift + cmd - 3 : /Applications/Flameshot.app/Contents/MacOS/flameshot full
-    '';
+  launchd.user.agents.flameshot = {
+    serviceConfig = {
+      KeepAlive = true;
+      ProgramArguments = ["/Applications/Flameshot.app/Contents/MacOS/flameshot"];
+      ProcessType = "Interactive";
+      RunAtLoad = true;
+    };
   };
 
   # Enable fonts


### PR DESCRIPTION
## Summary

This PR removes the remaining Darwin dependency on `skhd` for screenshot shortcuts and hardens the macOS browser-default setup that was blocking `darwin-rebuild`.

## What Changed

- removed the `skhd` service from the Darwin host configuration
- added a persistent `launchd` agent for Flameshot instead
- kept the native macOS screenshot chords disabled so Flameshot can own the ones it supports directly
- added `home-manager/config/flameshot/flameshot.ini` and deploy it through Home Manager
- mapped Flameshot native shortcuts for:
  - `Cmd+Shift+4` via `TAKE_SCREENSHOT`
  - `Cmd+Shift+3` via `SCREENSHOT_HISTORY`
- documented that the clipboard variants remain disabled because Flameshot does not expose native macOS global bindings for them
- replaced the `duti` activation hook with a small LaunchServices helper that checks current handlers before attempting to set Vivaldi as the default browser
- downgraded browser-registration failure from a hard activation break to a warning so existing handlers remain untouched if LaunchServices refuses the change

## Why

`skhd` was unreliable on macOS because Secure Keyboard Entry regularly prevented it from installing its event tap. Flameshot’s native macOS global shortcuts are a better fit for screenshot capture here.

Separately, `duti` was failing to register Vivaldi for `http` and `https`, which blocked `darwin-rebuild switch`. Using LaunchServices directly fixes the rebuild path while preserving the existing default-handler state if macOS rejects the update.

## Validation

- reloaded the live Flameshot launch agent after the shortcut update
- verified the edited files are error-free in the workspace
- ran:

```bash
nix build .#darwinConfigurations.darwin.config.system.build.toplevel --no-link
```

## Notes

This commit intentionally contains only the Darwin screenshot/browser changes from this session. Other unrelated local edits in the worktree were left out of the branch commit.