### PR TITLE
Add VS Code Insiders editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,10 @@ Includes:
 
 ## Editor Configuration
 
-- `home-manager/common.nix` is the source for persistent VS Code user defaults applied through Home Manager.
+- `home-manager/lib/code-editor-user-settings.nix` is the shared source for persistent VS Code and VS Code Insiders user settings.
+- `home-manager/common.nix` and `home-manager/home-darwin.nix` install those settings and Copilot prompt files into each editor's user config directory.
 - `.devcontainer/devcontainer.json` is only the bootstrap layer for container sessions before the Home Manager profile is applied.
-- `.vscode/settings.json` and `.vscode/extensions.json` are the repository-specific layer and should stay focused on workspace behavior such as the Nix formatter, language server, and extension recommendations.
+- `.vscode/settings.json` and `.vscode/extensions.json` are the repository-specific layer and should stay focused on workspace behavior such as the Nix formatter, language server, and extension recommendations for VS Code-compatible editors, including VS Code Insiders.
 - If a setting should follow you across machines, keep it in Home Manager. If it should apply only to this repository, keep it in `.vscode`.
 
 ## Service Tasks

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -6,39 +6,7 @@
   ...
 }: let
   availableOnHost = pkg: lib.meta.availableOn pkgs.stdenv.hostPlatform pkg;
-  vscodeUserSettings = {
-    # Fonts consistent with Stylix
-    "editor.fontFamily" = "FiraCode Nerd Font Mono";
-    "terminal.integrated.fontFamily" = "FiraCode Nerd Font Mono";
-    "terminal.integrated.defaultProfile.linux" = "zsh";
-    "terminal.integrated.profiles.linux" = {
-      zsh = {
-        path = "${pkgs.zsh}/bin/zsh";
-        args = ["-l"];
-      };
-    };
-
-    # Small quality-of-life defaults (non-Stylix)
-    "editor.fontLigatures" = true;
-    "editor.formatOnSave" = true;
-    "[nix]" = {
-      "editor.defaultFormatter" = "jnoortheen.nix-ide";
-    };
-    "nix.formatterPath" = "alejandra";
-    "nix.enableLanguageServer" = true;
-    "nix.serverPath" = "nixd";
-    "nix.serverSettings" = {
-      nixd = {
-        formatting.command = ["alejandra"];
-      };
-    };
-    "files.trimTrailingWhitespace" = true;
-    "files.insertFinalNewline" = true;
-    "chat.mcp.gallery.enabled" = true;
-    "cSpell.enabled" = false;
-    "git.blame.editorDecoration.enabled" = true;
-    "git.autofetch" = true;
-  };
+  codeEditorUserSettings = import ./lib/code-editor-user-settings.nix {inherit pkgs;};
   awsSamCliPatched = pkgs.aws-sam-cli.overridePythonAttrs (old: {
     # nixpkgs currently wires newer click and aws-lambda-builders versions than
     # the wheel metadata expects. Keep the package Nix-managed and skip the
@@ -141,12 +109,18 @@ in {
     stateVersion = "25.05";
 
     # Make Copilot defaults visible to desktop, remote, and shared IDE sessions.
-    file = {
-      ".config/Code/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
-      ".vscode-server/data/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
-      ".config/github-copilot/copilot-defaults.instructions.md".source = copilotDefaultsFile;
-      ".config/github-copilot/intellij/global-copilot-instructions.md".source = copilotDefaultsFile;
-    };
+    file =
+      {
+        ".config/Code/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
+        ".config/Code - Insiders/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
+        ".vscode-server/data/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
+        ".vscode-server-insiders/data/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
+        ".config/github-copilot/copilot-defaults.instructions.md".source = copilotDefaultsFile;
+        ".config/github-copilot/intellij/global-copilot-instructions.md".source = copilotDefaultsFile;
+      }
+      // lib.optionalAttrs (!isWsl && pkgs.stdenv.isLinux) {
+        ".config/Code - Insiders/User/settings.json".text = builtins.toJSON codeEditorUserSettings;
+      };
   };
 
   # Common font configuration
@@ -219,7 +193,7 @@ in {
       enable = true;
       profiles.default = {
         extensions = lib.mkAfter [pkgs.vscode-extensions.jnoortheen.nix-ide];
-        userSettings = vscodeUserSettings;
+        userSettings = codeEditorUserSettings;
       };
     };
 

--- a/home-manager/config/copilot/README.md
+++ b/home-manager/config/copilot/README.md
@@ -18,7 +18,7 @@ home-manager/config/copilot/copilot-defaults.instructions.md
 
 ## VS Code Targets
 
-### macOS
+### VS Code macOS
 
 Copy or symlink the source file to:
 
@@ -34,7 +34,7 @@ ln -sf "$HOME/.config/nix/home-manager/config/copilot/copilot-defaults.instructi
   "$HOME/Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md"
 ```
 
-### Linux
+### VS Code Linux
 
 Copy or symlink the source file to:
 
@@ -50,7 +50,41 @@ ln -sf "$HOME/.config/nix/home-manager/config/copilot/copilot-defaults.instructi
   "$HOME/.config/Code/User/prompts/copilot-defaults.instructions.md"
 ```
 
-### Remote / WSL / VS Code Server
+## VS Code Insiders Targets
+
+### VS Code Insiders macOS
+
+Copy or symlink the source file to:
+
+```text
+~/Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md
+```
+
+Example:
+
+```sh
+mkdir -p "$HOME/Library/Application Support/Code - Insiders/User/prompts"
+ln -sf "$HOME/.config/nix/home-manager/config/copilot/copilot-defaults.instructions.md" \
+  "$HOME/Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md"
+```
+
+### VS Code Insiders Linux
+
+Copy or symlink the source file to:
+
+```text
+~/.config/Code - Insiders/User/prompts/copilot-defaults.instructions.md
+```
+
+Example:
+
+```sh
+mkdir -p "$HOME/.config/Code - Insiders/User/prompts"
+ln -sf "$HOME/.config/nix/home-manager/config/copilot/copilot-defaults.instructions.md" \
+  "$HOME/.config/Code - Insiders/User/prompts/copilot-defaults.instructions.md"
+```
+
+### VS Code Remote / WSL
 
 If you want the same defaults in remote sessions, also copy or symlink the file
 to:
@@ -65,6 +99,23 @@ Example:
 mkdir -p "$HOME/.vscode-server/data/User/prompts"
 ln -sf "$HOME/.config/nix/home-manager/config/copilot/copilot-defaults.instructions.md" \
   "$HOME/.vscode-server/data/User/prompts/copilot-defaults.instructions.md"
+```
+
+### VS Code Insiders Remote / WSL
+
+If you want the same defaults in remote Insiders sessions, also copy or symlink
+the file to:
+
+```text
+~/.vscode-server-insiders/data/User/prompts/copilot-defaults.instructions.md
+```
+
+Example:
+
+```sh
+mkdir -p "$HOME/.vscode-server-insiders/data/User/prompts"
+ln -sf "$HOME/.config/nix/home-manager/config/copilot/copilot-defaults.instructions.md" \
+  "$HOME/.vscode-server-insiders/data/User/prompts/copilot-defaults.instructions.md"
 ```
 
 ## GitHub Copilot User Config Targets

--- a/home-manager/home-darwin.nix
+++ b/home-manager/home-darwin.nix
@@ -3,6 +3,7 @@
   lib,
   ...
 }: let
+  codeEditorUserSettings = import ./lib/code-editor-user-settings.nix {inherit pkgs;};
   vivaldiBrowserWrapper = pkgs.writeShellScriptBin "vivaldi" ''
     exec /usr/bin/open -a "Vivaldi" "$@"
   '';
@@ -220,10 +221,55 @@ in {
           echo "Skipping Vivaldi default browser registration: /Applications/Vivaldi.app is unavailable."
         fi
       '';
+
+      syncCodeInsidersExtensions = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        stable_code="/opt/homebrew/bin/code"
+        insiders_code="/opt/homebrew/bin/code-insiders"
+
+        if [ ! -x "$stable_code" ] || [ ! -x "$insiders_code" ]; then
+          echo "Skipping VS Code Insiders extension sync: code or code-insiders is unavailable."
+        else
+          mkdir -p "$HOME/.vscode-insiders/extensions"
+          tmp_dir="$(${pkgs.coreutils}/bin/mktemp -d)"
+          cleanup() {
+            ${pkgs.coreutils}/bin/rm -rf "$tmp_dir"
+          }
+          trap cleanup EXIT INT TERM
+
+          "$stable_code" --list-extensions | ${pkgs.coreutils}/bin/sort -u > "$tmp_dir/stable-extensions.txt"
+          "$insiders_code" --list-extensions | ${pkgs.coreutils}/bin/sort -u > "$tmp_dir/insiders-extensions.txt"
+
+          ${pkgs.coreutils}/bin/comm -23 "$tmp_dir/stable-extensions.txt" "$tmp_dir/insiders-extensions.txt" | while IFS= read -r extension; do
+            if [ -z "$extension" ]; then
+              continue
+            fi
+
+            echo "Installing VS Code Insiders extension: $extension"
+            if ! "$insiders_code" --install-extension "$extension" >/dev/null 2>&1; then
+              extension_store_path="$(${pkgs.findutils}/bin/find /nix/store -path "*/share/vscode/extensions/$extension" 2>/dev/null | ${pkgs.coreutils}/bin/head -n 1)"
+              if [ -n "$extension_store_path" ]; then
+                extension_version="$(${pkgs.jq}/bin/jq -r '.version // "nix"' "$extension_store_path/package.json" 2>/dev/null)"
+                ${pkgs.coreutils}/bin/ln -sfn "$extension_store_path" "$HOME/.vscode-insiders/extensions/$extension-$extension_version"
+                echo "Linked Nix-managed VS Code Insiders extension: $extension"
+              else
+                echo "Warning: failed to install VS Code Insiders extension '$extension'"
+              fi
+            fi
+          done
+
+          cleanup
+          trap - EXIT INT TERM
+        fi
+      '';
     };
 
-    # Install the shared Copilot defaults into the macOS VS Code user prompts directory.
-    file."Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md".source = ./config/copilot/copilot-defaults.instructions.md;
+    # Install shared editor settings and Copilot defaults into the macOS
+    # user configuration directories for the stable and Insiders VS Code apps.
+    file = {
+      "Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md".source = ./config/copilot/copilot-defaults.instructions.md;
+      "Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md".source = ./config/copilot/copilot-defaults.instructions.md;
+      "Library/Application Support/Code - Insiders/User/settings.json".text = builtins.toJSON codeEditorUserSettings;
+    };
   };
 
   # Darwin-specific Stylix targets (extending common.nix)

--- a/home-manager/home-wsl.nix
+++ b/home-manager/home-wsl.nix
@@ -84,29 +84,7 @@
 
   availableOnHost = pkg: lib.meta.availableOn pkgs.stdenv.hostPlatform pkg;
   availableLinuxPackages = lib.filter availableOnHost linuxPackages;
-  vscodeUserSettings = {
-    "editor.fontFamily" = "FiraCode Nerd Font Mono";
-    "terminal.integrated.fontFamily" = "FiraCode Nerd Font Mono";
-    "terminal.integrated.defaultProfile.linux" = "zsh";
-    "terminal.integrated.profiles.linux" = {
-      zsh = {
-        path = "${pkgs.zsh}/bin/zsh";
-        args = ["-l"];
-      };
-    };
-    "editor.fontLigatures" = true;
-    "editor.formatOnSave" = true;
-    "[nix]" = {
-      "editor.defaultFormatter" = "jnoortheen.nix-ide";
-    };
-    "nix.formatterPath" = "alejandra";
-    "files.trimTrailingWhitespace" = true;
-    "files.insertFinalNewline" = true;
-    "chat.mcp.gallery.enabled" = true;
-    "cSpell.enabled" = false;
-    "git.blame.editorDecoration.enabled" = true;
-    "git.autofetch" = true;
-  };
+  codeEditorUserSettings = import ./lib/code-editor-user-settings.nix {inherit pkgs;};
 in {
   _module.args.isWsl = true;
 
@@ -199,12 +177,20 @@ in {
       fi
     '';
 
-    file.".vscode-server/data/User/settings.json".text = builtins.toJSON vscodeUserSettings;
-
-    file.".vscode-server/data/Machine/settings.json".text = builtins.toJSON {
-      "terminal.integrated.automationProfile.linux" = {
-        path = "${pkgs.zsh}/bin/zsh";
-        args = ["-l"];
+    file = {
+      ".vscode-server/data/User/settings.json".text = builtins.toJSON codeEditorUserSettings;
+      ".vscode-server-insiders/data/User/settings.json".text = builtins.toJSON codeEditorUserSettings;
+      ".vscode-server/data/Machine/settings.json".text = builtins.toJSON {
+        "terminal.integrated.automationProfile.linux" = {
+          path = "${pkgs.zsh}/bin/zsh";
+          args = ["-l"];
+        };
+      };
+      ".vscode-server-insiders/data/Machine/settings.json".text = builtins.toJSON {
+        "terminal.integrated.automationProfile.linux" = {
+          path = "${pkgs.zsh}/bin/zsh";
+          args = ["-l"];
+        };
       };
     };
   };

--- a/home-manager/lib/code-editor-user-settings.nix
+++ b/home-manager/lib/code-editor-user-settings.nix
@@ -1,0 +1,51 @@
+{pkgs}: {
+  # Fonts consistent with Stylix
+  "chat.editor.fontFamily" = "FiraCode Nerd Font Mono";
+  "chat.editor.fontSize" = 16.0;
+  "chat.fontFamily" = "Inter";
+  "debug.console.fontFamily" = "FiraCode Nerd Font Mono";
+  "debug.console.fontSize" = 16.0;
+  "editor.fontFamily" = "FiraCode Nerd Font Mono";
+  "terminal.integrated.fontFamily" = "FiraCode Nerd Font Mono";
+  "terminal.integrated.fontSize" = 16.0;
+  "terminal.integrated.defaultProfile.linux" = "zsh";
+  "terminal.integrated.profiles.linux" = {
+    zsh = {
+      path = "${pkgs.zsh}/bin/zsh";
+      args = ["-l"];
+    };
+  };
+
+  # Small quality-of-life defaults (non-Stylix)
+  "editor.fontSize" = 16.0;
+  "editor.fontLigatures" = true;
+  "editor.formatOnSave" = true;
+  "editor.inlayHints.fontFamily" = "FiraCode Nerd Font Mono";
+  "editor.inlineSuggest.fontFamily" = "FiraCode Nerd Font Mono";
+  "editor.minimap.sectionHeaderFontSize" = 10.285714285714286;
+  "[nix]" = {
+    "editor.defaultFormatter" = "jnoortheen.nix-ide";
+  };
+  "nix.formatterPath" = "alejandra";
+  "nix.enableLanguageServer" = true;
+  "nix.serverPath" = "nixd";
+  "nix.serverSettings" = {
+    nixd = {
+      formatting.command = ["alejandra"];
+    };
+  };
+  "files.trimTrailingWhitespace" = true;
+  "files.insertFinalNewline" = true;
+  "chat.mcp.access" = "all";
+  "chat.mcp.gallery.enabled" = true;
+  "cSpell.enabled" = false;
+  "git.blame.editorDecoration.enabled" = true;
+  "git.autofetch" = true;
+  "markdown.preview.fontFamily" = "Inter";
+  "markdown.preview.fontSize" = 16.0;
+  "notebook.markup.fontFamily" = "Inter";
+  "scm.inputFontFamily" = "FiraCode Nerd Font Mono";
+  "scm.inputFontSize" = 14.857142857142858;
+  "screencastMode.fontSize" = 64.0;
+  "workbench.colorTheme" = "Stylix";
+}

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -27,8 +27,12 @@ _: {
       fi
 
       # Enable VS Code terminal shell integration even with custom zsh init.
-      if [[ "$TERM_PROGRAM" == "vscode" ]] && command -v code >/dev/null 2>&1; then
-        source "$(code --locate-shell-integration-path zsh)"
+      if [[ "$TERM_PROGRAM" == "vscode" || "$TERM_PROGRAM" == "vscode-insiders" ]]; then
+        if command -v code-insiders >/dev/null 2>&1; then
+          source "$(code-insiders --locate-shell-integration-path zsh)"
+        elif command -v code >/dev/null 2>&1; then
+          source "$(code --locate-shell-integration-path zsh)"
+        fi
       fi
 
       # Initialize shell integrations

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -224,6 +224,7 @@
     casks = [
       # GUI applications that work better via Homebrew
       "android-platform-tools"
+      "corretto@11" # AWS Corretto 11 JDK for Java tooling compatibility
       "chromium" # Chromium Browser
       "dbeaver-community" # Database management tool
       "discord" # Discord
@@ -242,6 +243,7 @@
       "session-manager-plugin"
       "slack" # Team communication
       "visual-studio-code" # VS Code
+      "visual-studio-code@insiders" # VS Code Insiders
       "vivaldi" # Vivaldi Browser
       "whatsapp"
     ];


### PR DESCRIPTION
## Summary

- add a shared `home-manager/lib/code-editor-user-settings.nix` module and reuse it for persistent VS Code user settings instead of duplicating stable-editor settings in multiple Home Manager entrypoints
- install shared Copilot prompt defaults and user settings for VS Code Insiders on macOS, Linux, WSL, and remote/server targets, and update the repository documentation to point at the shared editor-settings source of truth
- extend Darwin support by syncing stable VS Code extensions into VS Code Insiders during activation, adding the VS Code Insiders and Corretto 11 Homebrew casks, and teaching shared Zsh shell integration to work with either stable or Insiders

## Why

These changes make VS Code Insiders a first-class editor target in the same way stable VS Code is already managed here, while keeping the user settings declarative and shared across platforms.

## Validation

- `task fmt:check`
- `task lint:nix`
- `nix flake check --print-build-logs`