### PR TITLE
fix(claude): deploy CLAUDE.md via xdg.configFile to respect CLAUDE_CONFIG_DIR

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1776894428,
-        "narHash": "sha256-wuT915MyCtMTfLj+uo9y8wtCwkEgJXiXvcbSleFrlN0=",
+        "lastModified": 1777581180,
+        "narHash": "sha256-JcDBTZkkz68WlZKYDoD+MZG8b3dnIJXqMvyuVx3Wkdg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f34be27ce83efaa1c85ad1e5b1f8b6dea65b147d",
+        "rev": "a2538cd28ae2140ffce9cee9108b8d569a9c4fed",
         "type": "github"
       },
       "original": {

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -152,6 +152,10 @@ in {
     configHome = xdgConfigHome;
     dataHome = xdgDataHome;
     stateHome = xdgStateHome;
+
+    # Deploy Claude Code global user instructions under XDG so they track
+    # the CLAUDE_CONFIG_DIR exported in zsh.nix ($XDG_CONFIG_HOME/claude).
+    configFile."claude/CLAUDE.md".source = claudeDefaultsFile;
   };
 
   home = {
@@ -179,13 +183,11 @@ in {
     stateVersion = "25.05";
 
     # Make Copilot defaults visible to desktop, remote, and shared IDE sessions.
-    # Deploy Claude Code global user instructions alongside the Copilot defaults.
     file = {
       ".config/Code/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
       ".vscode-server/data/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
       ".config/github-copilot/copilot-defaults.instructions.md".source = copilotDefaultsFile;
       ".config/github-copilot/intellij/global-copilot-instructions.md".source = copilotDefaultsFile;
-      ".claude/CLAUDE.md".source = claudeDefaultsFile;
     };
   };
 


### PR DESCRIPTION
## Summary

- Moves the Claude Code global instructions file (`CLAUDE.md`) from `home.file` to `xdg.configFile` so it is deployed to `$XDG_CONFIG_HOME/claude/CLAUDE.md` instead of the hardcoded `~/.claude/CLAUDE.md`.
- This aligns with the `CLAUDE_CONFIG_DIR` env var exported in `zsh.nix`, which points to `$XDG_CONFIG_HOME/claude`.
- Bumps the `stylix` flake input to the latest upstream revision (`a2538cd`).

## Why

The previous `home.file` approach ignored the `CLAUDE_CONFIG_DIR` env var and always wrote to `~/.claude/CLAUDE.md`. By switching to `xdg.configFile`, the file lands where Claude Code actually looks for it when `CLAUDE_CONFIG_DIR` is set.

## Reviewer notes

- No functional change to Copilot instruction deployment — only the Claude path is affected.
- The comment in `home.file` that mentioned Claude has been removed since it no longer applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)