### PR TITLE
fix(claude): restore ~/.claude/CLAUDE.md so memory file auto-loads

### DIFF
--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -161,8 +161,10 @@ in {
     dataHome = xdgDataHome;
     stateHome = xdgStateHome;
 
-    # Deploy Claude Code global user instructions under XDG so they track
-    # the CLAUDE_CONFIG_DIR exported in zsh.nix ($XDG_CONFIG_HOME/claude).
+    # Canonical XDG location for Claude Code global user instructions.
+    # CLAUDE_CONFIG_DIR (exported in zsh.nix as $XDG_CONFIG_HOME/claude) drives
+    # state files like .claude.json, but does NOT drive memory-file resolution
+    # — see also home.file.".claude/CLAUDE.md" below.
     configFile."claude/CLAUDE.md".source = claudeDefaultsFile;
   };
 
@@ -219,6 +221,16 @@ in {
       ".vscode-server/data/User/prompts/copilot-defaults.instructions.md".source = copilotDefaultsFile;
       ".config/github-copilot/copilot-defaults.instructions.md".source = copilotDefaultsFile;
       ".config/github-copilot/intellij/global-copilot-instructions.md".source = copilotDefaultsFile;
+
+      # Claude Code's memory-file loader hardcodes ~/.claude/CLAUDE.md and does
+      # not honor CLAUDE_CONFIG_DIR — see https://code.claude.com/docs/en/memory.md.
+      # PR #20 moved this file to the XDG location alone, which silently broke
+      # auto-loading. Until Anthropic teaches the loader to follow
+      # CLAUDE_CONFIG_DIR (or another XDG-aware mechanism), we deploy the same
+      # source to both paths so XDG remains canonical and the legacy path acts
+      # as a forwarding pointer the loader can find. Revisit and remove this
+      # entry once the upstream fix lands.
+      ".claude/CLAUDE.md".source = claudeDefaultsFile;
     };
   };
 


### PR DESCRIPTION
## Summary

- Restores `~/.claude/CLAUDE.md` as a home-manager-managed symlink alongside the existing `xdg.configFile."claude/CLAUDE.md"` entry — both deploy from the same `claudeDefaultsFile` source so XDG remains canonical and there is no drift risk.
- Updates the in-file comments to be honest about why both paths are needed and what the long-term exit looks like.

## Why

[PR #20](https://github.com/borland502/nix-config/pull/20) moved the file to the XDG location alone, claiming this would let it "track `CLAUDE_CONFIG_DIR`". That premise was wrong: per the [official docs](https://code.claude.com/docs/en/memory.md), Claude Code's memory-file loader hardcodes `~/.claude/CLAUDE.md` and does **not** honor `CLAUDE_CONFIG_DIR` (which only drives state files like `.claude.json`). The result was that Claude Code silently launched without the user's persistent directives — visible only when the user noticed the assistant ignoring them.

## Long-term plan

The new comment block in `common.nix` flags this as a workaround pending an upstream fix that teaches the Claude Code memory loader to follow `CLAUDE_CONFIG_DIR` (or another XDG-aware mechanism). Once that lands, the `home.file.".claude/CLAUDE.md"` entry can be removed and only the `xdg.configFile` entry will remain.

## Reviewer notes

- Both deployments point at the same `claudeDefaultsFile` source, so editing either path edits the same file under the hood — no two-source drift.
- No change to Copilot / agent-instructions wiring.
- Pre-commit hooks (statix, deadnix, copilot/agent instruction sync checks) all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)