### PR TITLE
feat(skills): surface buried behaviors as discoverable skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ The shells export `CLAUDE_CONFIG_DIR` and `COPILOT_CONFIG_DIR` (defined in [`hom
 
 ### Upstream credits
 
-Skills under `ai-tools/skills/` other than the project-local ones (`ops-cache-scan`, `ops-chezmoi`, `cli-dasel`, `cli-fd`, `cli-fzf`, `cli-jq`, `ops-nix-pitfalls`, `ops-agent`, `flow-reconciliation`, `cli-rg`, `cli-sd`, `sec-sops-encrypt`, `cli-yq`) were ingested from upstream repositories. Each retains its `origin:` frontmatter for traceability, and any required attribution / license text is preserved verbatim alongside the skill.
+Skills under `ai-tools/skills/` other than the project-local ones (`ops-cache-scan`, `ops-chezmoi`, `cli-dasel`, `cli-fd`, `cli-fzf`, `cli-jq`, `ops-nix-pitfalls`, `ops-agent`, `flow-reconciliation`, `cli-rg`, `cli-sd`, `sec-credentials`, `sec-sops-encrypt`, `shell-pitfalls`, `cli-yq`) were ingested from upstream repositories. Each retains its `origin:` frontmatter for traceability, and any required attribution / license text is preserved verbatim alongside the skill.
 
 | Upstream repo | License | Skills ingested |
 |---|---|---|

--- a/TODO.md
+++ b/TODO.md
@@ -115,55 +115,27 @@ fresh session has no skill to discover them.
 
 **New skills (2):**
 
-* **`sec-credentials`** — codifies the CLAUDE.md rule "check `~/.cache`
+* ~~**`sec-credentials`** — codifies the CLAUDE.md rule "check `~/.cache`
   then `~/.config` for tool credentials" and the sops → legacy-path
-  fallback pattern implemented in
-  [home-manager/local/bin/ops-agent.py](home-manager/local/bin/ops-agent.py).
-  Triggers on "where's the token / auth / credential for X" type
-  questions. Should reference `sec-sops-encrypt` for the encryption
-  side and `ops-agent` for the canonical fallback example.
+  fallback pattern implemented in `ops-agent.py`.~~ — landed
 
-* **`shell-pitfalls`** — consolidates shell anti-patterns currently
+* ~~**`shell-pitfalls`** — consolidates shell anti-patterns currently
   scattered across instruction files: aliases hide real binaries (use
   `/bin/ls`, `/bin/cat` when exact output is needed); zsh `status` is
-  read-only (use `rc` or `exit_code`); the heavy-quoting heuristic
-  from [agent-defaults.md:27](chezmoi/dot_config/instructions/agent-defaults.md#L27)
-  ("when a command with JSON payloads or heavy quoting fails, write a
-  short script file under `~/.cache/<agent>/` and execute that
-  instead of retrying inline `zsh -c`"); the wrapped-capture
-  permission-denied retry trick from
-  [agent-defaults.md:25](chezmoi/dot_config/instructions/agent-defaults.md#L25).
-  Could alternatively be folded into `ops-nix-pitfalls` if we don't
-  want a separate skill.
+  read-only; the heavy-quoting heuristic; the wrapped-capture
+  permission-denied retry trick.~~ — landed
 
 **Skill updates (3):**
 
-* **`jira-integration` → make REST-first explicit.** CLAUDE.md says
-  prefer direct REST/API requests over `jira-cli`/`confluence-cli`
-  wrappers. Today this is a one-liner in CLAUDE.md and the skill
-  doesn't enforce it. Promote REST as the loud default; demote CLI
-  wrappers to a "fallback when no token is available" footnote.
+* ~~**`jira-integration` → make REST-first explicit.**~~ — landed
 
-* **`ops-cache-scan` (post-rename) → document the log source.** The
-  `PostToolUse` hook in
-  [home-manager/common.nix:228-239](home-manager/common.nix#L228-L239)
-  pipes every Bash command + output to `~/.cache/<agent>/*.log` via
-  [home-manager/local/bin/log-bash.sh](home-manager/local/bin/log-bash.sh).
-  Add a one-paragraph pointer in the SKILL.md so future sessions know
-  why those logs exist and that the hook is automatic (not something
-  to wire up themselves).
+* ~~**`ops-cache-scan` (post-rename) → document the log source.**~~ — landed
 
-* **`flow-systematic-debugging` (post-rename) → add a Phase 0 "check
-  the log first."** Codifies the procedure from
-  [agent-defaults.md:10](chezmoi/dot_config/instructions/agent-defaults.md#L10):
-  before retrying a failed command, grep `~/.cache/<agent>/*.log` for
-  prior successful invocations of the same tool and use them as
-  concrete templates. Pairs naturally with the `ops-cache-scan`
-  update — that skill produces the index, this one consumes it.
+* ~~**`flow-systematic-debugging` (post-rename) → add a Phase 0 "check
+  the log first."**~~ — landed
 
-* **`ops-nix-pitfalls` (post-rename) → optional sink for shell
-  pitfalls.** If we don't create a standalone `shell-pitfalls` skill,
-  fold the alias-escaping / zsh-`status` content here.
+* ~~**`ops-nix-pitfalls` (post-rename) → optional sink for shell
+  pitfalls.**~~ — moot: standalone `shell-pitfalls` skill landed instead.
 
 **Explicitly NOT skills:**
 

--- a/ai-tools/skills/flow-systematic-debugging/SKILL.md
+++ b/ai-tools/skills/flow-systematic-debugging/SKILL.md
@@ -43,9 +43,32 @@ Use for ANY technical issue:
 - You're in a hurry (rushing guarantees rework)
 - Manager wants it fixed NOW (systematic is faster than thrashing)
 
-## The Four Phases
+## The Phases
 
-You MUST complete each phase before proceeding to the next.
+You MUST complete each phase before proceeding to the next. Phase 0 is a preflight that runs before any new investigation; Phases 1–4 are the core debugging loop.
+
+### Phase 0: Check the Log First
+
+**BEFORE you reproduce, BEFORE you re-run the failing command:** check whether you (or a prior session) have already invoked the same command successfully under `~/.cache/<agent>/*.log`. The PostToolUse hook in [home-manager/common.nix](../../../home-manager/common.nix) writes every Bash invocation + output to that directory automatically — so a prior successful run is on disk, not lost to history.
+
+This codifies the rule from [chezmoi/dot_config/instructions/agent-defaults.md L10](../../../chezmoi/dot_config/instructions/agent-defaults.md): *"When investigating tool or command failures, inspect relevant logs under `~/.cache/@@AGENT@@` first; use prior successful executions there as concrete examples before retrying or changing approach."*
+
+```bash
+# Find prior runs of the failing command (replace <pattern>)
+rg -l '<pattern>' ~/.cache/claude/*.log ~/.cache/copilot/*.log 2>/dev/null
+
+# Or use the helper skill to summarize recent activity
+cache-scan --days 3
+```
+
+For the index-side workflow (browsing recent activity, classifying failures, picking up a resume point), see the **[cache-scan](../cache-scan/SKILL.md)** skill — that skill produces the index, this Phase 0 consumes it.
+
+**What to look for:**
+- A prior **successful** invocation of the same tool/binary with similar arguments — copy that invocation as a known-good template.
+- A prior **failure** with the same signature — read what was tried last time before repeating it.
+- Environment differences between then and now (cwd, env vars echoed in the log, tool version).
+
+**When to skip Phase 0:** brand-new tooling that has never been invoked before, or a problem that has nothing to do with command invocation (UI bug, design question). Phase 0 is for retrying or re-investigating a *command* failure.
 
 ### Phase 1: Root Cause Investigation
 

--- a/ai-tools/skills/ops-cache-scan/SKILL.md
+++ b/ai-tools/skills/ops-cache-scan/SKILL.md
@@ -7,6 +7,12 @@ description: Scan cache logs for recent activity, failures, and resumable contex
 
 Use this skill when the user asks to recover context from recent cache activity, resume prior work, or summarize failures from terminal logs.
 
+## Why those logs exist
+
+The logs under `~/.cache/<agent>/*.log` (where `<agent>` is `claude` or `copilot`) are populated automatically by a `PostToolUse` hook wired up in [home-manager/common.nix L228-L239](../../../home-manager/common.nix#L228-L239). Every Bash invocation the agent runs is piped through [home-manager/local/bin/log-bash.sh](../../../home-manager/local/bin/log-bash.sh), which writes the exact command and its output to a timestamped file in the agent's cache dir. Activation also enforces `~/.cache/claude` → `~/.cache/copilot` as a symlink so both agents share one log dir.
+
+This is *not* something a session needs to wire up — if the host has had `home-manager switch` run successfully, the hook is already firing on every Bash call. This skill consumes that log stream; it does not produce it. The companion read-side workflow lives in [flow-systematic-debugging](../flow-systematic-debugging/SKILL.md) Phase 0.
+
 ## Inputs
 
 - Optional date in `YYYY-MM-DD` format. Defaults to today.

--- a/ai-tools/skills/ops-jira-integration/SKILL.md
+++ b/ai-tools/skills/ops-jira-integration/SKILL.md
@@ -6,7 +6,11 @@ origin: ECC
 
 # Jira Integration Skill
 
-Retrieve, analyze, and update Jira tickets directly from your AI coding workflow. Supports both **MCP-based** (recommended) and **direct REST API** approaches.
+Retrieve, analyze, and update Jira tickets directly from your AI coding workflow.
+
+> **This repo's policy: prefer direct REST API calls over CLI wrappers.**
+> [chezmoi/dot_config/instructions/agent-defaults.md L12](../../../chezmoi/dot_config/instructions/agent-defaults.md): *"For Jira and Confluence operations, prefer direct REST/API-spec requests with configured tokens over dedicated `jira-cli` or `confluence-cli` wrappers."*
+> Use the **REST API path (Option A below)** by default. The MCP integration (Option B) is a valid alternative when it's already configured for this user, but don't introduce or recommend `jira-cli`/`confluence-cli` wrappers.
 
 ## When to Activate
 
@@ -19,13 +23,30 @@ Retrieve, analyze, and update Jira tickets directly from your AI coding workflow
 
 ## Prerequisites
 
-### Option A: MCP Server (Recommended)
+### Option A: Direct REST API (default)
 
-Install the `mcp-atlassian` MCP server. This exposes Jira tools directly to your AI agent.
+Use the Jira REST API v3 directly via `curl` or a helper script. This is the loud default per the policy above — no extra dependencies, no opaque wrapper layer, and the auth flow lives in plain shell.
 
-**Requirements:**
-- Python 3.10+
-- `uvx` (from `uv`), installed via your package manager or the official `uv` installation documentation
+**Required environment variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `JIRA_URL` | Your Jira instance URL (e.g., `https://yourorg.atlassian.net`) |
+| `JIRA_EMAIL` | Your Atlassian account email |
+| `JIRA_API_TOKEN` | API token from id.atlassian.com |
+
+**Where to find the token in this repo's setup:**
+- sops-decrypted runtime path (preferred): `~/.config/ops-agent/jira-token` — populated by [home-manager/modules/sops.nix](../../../home-manager/modules/sops.nix) when `~/.config/sops/age/keys.txt` is present.
+- See [sec-credentials](../sec-credentials/SKILL.md) for the full lookup precedence.
+
+**To create a fresh token:**
+1. Go to <https://id.atlassian.com/manage-profile/security/api-tokens>
+2. Click **Create API token**
+3. Add it to the encrypted secrets via [sec-sops-encrypt](../sec-sops-encrypt/SKILL.md) — never paste it into source code.
+
+### Option B: MCP Server (alternative when already configured)
+
+If the `mcp-atlassian` MCP server is already configured for the user, the JSON-RPC tooling layer is fine. Don't introduce it just for this task — REST is simpler. The MCP path has the same env-var requirements as REST.
 
 **Add to your MCP config** (e.g., `~/.claude.json` → `mcpServers`):
 
@@ -44,26 +65,9 @@ Install the `mcp-atlassian` MCP server. This exposes Jira tools directly to your
 }
 ```
 
-> **Security:** Never hardcode secrets. Prefer setting `JIRA_URL`, `JIRA_EMAIL`, and `JIRA_API_TOKEN` in your system environment (or a secrets manager). Only use the MCP `env` block for local, uncommitted config files.
+**Requirements:** Python 3.10+, `uvx` (from `uv`).
 
-**To get a Jira API token:**
-1. Go to <https://id.atlassian.com/manage-profile/security/api-tokens>
-2. Click **Create API token**
-3. Copy the token — store it in your environment, never in source code
-
-### Option B: Direct REST API
-
-If MCP is not available, use the Jira REST API v3 directly via `curl` or a helper script.
-
-**Required environment variables:**
-
-| Variable | Description |
-|----------|-------------|
-| `JIRA_URL` | Your Jira instance URL (e.g., `https://yourorg.atlassian.net`) |
-| `JIRA_EMAIL` | Your Atlassian account email |
-| `JIRA_API_TOKEN` | API token from id.atlassian.com |
-
-Store these in your shell environment, secrets manager, or an untracked local env file. Do not commit them to the repo.
+> **Security:** Never hardcode secrets. Prefer setting `JIRA_URL`, `JIRA_EMAIL`, and `JIRA_API_TOKEN` in your system environment (or sops-managed paths — see `sec-credentials`). Only use the MCP `env` block for local, uncommitted config files.
 
 ## MCP Tools Reference
 

--- a/ai-tools/skills/sec-credentials/SKILL.md
+++ b/ai-tools/skills/sec-credentials/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: sec-credentials
+description: Use when looking for an API token, auth key, or cached session for a tool (e.g. "where's the Jira token?", "how do I get the Anthropic key?"). Documents this repo's credential lookup precedence — sops-managed secrets, then the XDG config home, then the legacy fallback paths — so an agent never asks the user for credentials it could have read from disk.
+---
+
+# Credential Lookup
+
+Use this skill when a task needs a credential and you don't yet know where to find it. The repo has a deliberate precedence chain — check it before prompting the user.
+
+**Core principle:** look on disk before asking. The user has provisioned credentials once; if a tool can't find one, the path was probably wrong, not missing.
+
+## Precedence
+
+1. **sops-decrypted runtime path** — `~/.config/<tool>/<secret-name>` (no extension).
+   These are populated by [home-manager/modules/sops.nix](../../../home-manager/modules/sops.nix) at activation time from encrypted blobs in `secrets/` and the age key at `~/.config/sops/age/keys.txt`. Files appear only after `home-manager switch` has run with the age key present.
+
+2. **XDG config home** — `$XDG_CONFIG_HOME/<tool>/...` (defaults to `~/.config/<tool>/...`).
+   For tools that manage their own auth (`gh`, `aws`, `chezmoi`), this is where their config + token files live.
+
+3. **Cache home** — `$XDG_CACHE_HOME/<tool>/...` (defaults to `~/.cache/<tool>/...`).
+   Tools that cache short-lived session state (browser cookies, refreshed OAuth tokens, kerberos tickets) typically write here. Check this before prompting if a session-style credential is needed.
+
+4. **Legacy / tool-default path** — whatever the tool's docs specify (`~/.aws/credentials`, `~/.kube/config`, `~/.netrc`).
+   These are fallback locations the tool consults when XDG isn't honored. Some tools (notably `gh`) use the XDG path now; older ones still write here.
+
+5. **Last resort: prompt the user.** Only after the above four paths have all been checked.
+
+## Canonical example
+
+[home-manager/local/bin/ops-agent.py](../../../home-manager/local/bin/ops-agent.py) implements this pattern for the Jira token: read `~/.config/ops-agent/jira-token` (sops-decrypted), fall back to `~/.config/jira/token` (legacy), then error out. That precedence chain is the template — any new credential consumer in this repo should follow the same layering.
+
+## Quick checks
+
+```bash
+# Is the credential available as a sops-decrypted file?
+test -e "$HOME/.config/<tool>/<secret>" && echo "found at sops path"
+
+# Does the tool have its own XDG-aware config?
+ls "$XDG_CONFIG_HOME/<tool>/" 2>/dev/null
+
+# Is there a cached session?
+ls "$XDG_CACHE_HOME/<tool>/" 2>/dev/null
+
+# Last-resort tool-default path (tool-specific)
+ls "$HOME/.<tool>/" 2>/dev/null
+```
+
+## Cross-references
+
+- **[sec-sops-encrypt](../sec-sops-encrypt/SKILL.md)** — how secrets get into the sops-decrypted runtime paths in the first place. Read this when you need to *add* a new credential, not just find one.
+- **[ops-agent](../ops-agent/SKILL.md)** — the canonical consumer of this pattern. Its source is the live worked example.
+
+## Common pitfalls
+
+- **Don't `cat` decrypted secret files into terminal output.** They get logged by the PostToolUse hook to `~/.cache/<agent>/*.log`. Read with `python -c 'open("...").read().strip()'` and use the value, but don't echo it.
+- **Don't assume the file exists.** Activation may have failed or the user may not have an age key on this host. If the file isn't there, fall through to the next precedence step.
+- **Don't write a new credential to disk yourself.** Adding a secret means encrypting it with sops first — see `sec-sops-encrypt`.

--- a/ai-tools/skills/shell-pitfalls/SKILL.md
+++ b/ai-tools/skills/shell-pitfalls/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: shell-pitfalls
+description: Use when a shell command fails with a confusing error, an alias is interfering, a zsh wrapper script has a subtle bug, or a heavily-quoted inline `zsh -c` is failing repeatedly. Consolidates the shell anti-patterns this repo has been bitten by — alias escaping, the zsh `status` read-only trap, when to switch from inline commands to a script file, and the wrapped-capture permission-denied workaround.
+---
+
+# Shell Pitfalls
+
+Use this skill when a shell-level issue is the actual blocker — not a logic bug, not a missing file, but the *shell itself* doing something unexpected.
+
+## Aliases hide real binaries
+
+This repo's zsh config aliases `ls` → `eza` and `cat` → `bat` (see [home-manager/zsh.nix](../../../home-manager/zsh.nix)). Both replacements are great for humans but break when a script depends on the exact output format of the original.
+
+**Rule:** when you need exact, unstyled output, bypass the alias by calling the binary directly.
+
+```bash
+# Wrong: gets eza's columnar output, breaks downstream parsers
+files=$(ls /var/log/*.log)
+
+# Right: real BSD/GNU ls
+files=$(/bin/ls /var/log/*.log)
+
+# Wrong: gets bat's syntax highlighting + pager
+config=$(cat /etc/hosts)
+
+# Right: raw file contents
+config=$(/bin/cat /etc/hosts)
+```
+
+The same applies to anything you alias — `command <name>` works as a generic escape hatch (`command ls /tmp`) when you don't want to hardcode `/bin/`.
+
+## zsh `$status` is read-only
+
+In zsh, `status` is a read-only special variable (it mirrors `$?` for the previous pipeline). Assigning to it crashes the script.
+
+```zsh
+# Crashes: "status: read-only variable"
+status=0
+some_command
+status=$?
+
+# Use a different name
+rc=0
+some_command
+rc=$?
+
+# Or use $? directly without re-storing
+some_command
+if [[ $? -ne 0 ]]; then ...; fi
+```
+
+**Names to avoid as zsh variables:** `status`, `path`, `cdpath`, `fpath`, `manpath` — these are linked to special arrays/integers. `rc`, `exit_code`, `result` are safe.
+
+## Heavy quoting → write a script file
+
+When a `zsh -c '...'` fails because of nested quoting, JSON payloads, or escaped-and-re-escaped characters: **stop retrying inline.** Write the command to a file under `~/.cache/<agent>/` and execute the file.
+
+```bash
+# Wrong: shell-quoting hell, the second retry will fail differently from the first
+zsh -c "curl -X POST https://api.example.com/foo -H 'Content-Type: application/json' -d '{\"key\":\"value with spaces\"}'"
+
+# Right: file-based, no quote escaping
+mkdir -p ~/.cache/claude
+cat > ~/.cache/claude/post.sh <<'SCRIPT'
+#!/usr/bin/env zsh
+curl -X POST https://api.example.com/foo \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"value with spaces"}'
+SCRIPT
+chmod +x ~/.cache/claude/post.sh
+~/.cache/claude/post.sh
+```
+
+The file form is also re-runnable (the agent's PostToolUse hook captures the path and contents in the log) and edit-friendly when the API call needs adjusting.
+
+This is the codified version of the heuristic in [chezmoi/dot_config/instructions/agent-defaults.md L27](../../../chezmoi/dot_config/instructions/agent-defaults.md). When you find yourself on the third inline retry, stop and write a script.
+
+## Wrapped-capture permission-denied retry
+
+Some IDE harnesses wrap shell invocations in a capture command that tightens the executing process's permissions. If a script that *should* be executable returns `permission denied` only when wrapped — but works on a manual run — try invoking it with an explicit `/bin/zsh -f`:
+
+```bash
+# Fails inside wrapped capture: "permission denied"
+~/.local/bin/some-script.sh
+
+# Works: the explicit interpreter sidesteps the wrapper's exec restrictions
+/bin/zsh -f ~/.local/bin/some-script.sh
+```
+
+Per [agent-defaults.md L25](../../../chezmoi/dot_config/instructions/agent-defaults.md), retry with the explicit interpreter form *before* assuming a real file-permission problem.
+
+## When the problem isn't shell
+
+If you've reached this skill but none of the above patterns match, the problem probably isn't shell-level. Check:
+
+- Is the binary actually installed? `command -v <name>` (use `command`, not `which` — `which` is itself shell-specific in zsh).
+- Is `$PATH` what you expect? Aliases and `direnv` can mutate it inside the shell only.
+- Is the working directory what you expect? Shell history and IDE harnesses can confuse `cwd`.
+- Is the file mode actually executable? `stat -c '%A %n' <file>` (Linux) or `stat -f '%Sp %N' <file>` (macOS).
+
+After ruling those out, check [ops-nix-pitfalls](../ops-nix-pitfalls/SKILL.md) for nix-specific traps that surface as shell errors.
+
+## References
+
+- [chezmoi/dot_config/instructions/agent-defaults.md](../../../chezmoi/dot_config/instructions/agent-defaults.md) — the source instruction file these patterns are codified from.
+- [home-manager/zsh.nix](../../../home-manager/zsh.nix) — the alias definitions.


### PR DESCRIPTION
## Summary

Final item of the TODO.md plan. Two new skills + three updates make behaviors that were previously only in `CLAUDE.md`, hooks, or one-off scripts visible to fresh sessions as `/<command>` skills.

### New skills (2)

1. **`sec-credentials`** — credential-lookup precedence chain (sops-decrypted runtime path → XDG config home → cache home → tool default → prompt user). Triggers on "where's the X token?" type questions. Wired to `sec-sops-encrypt` (the encryption side) and `ops-agent` (the canonical consumer of this pattern).

2. **`shell-pitfalls`** — alias-escaping (`/bin/ls`, `/bin/cat` when exact output matters), zsh `$status` read-only trap, the heavy-quoting → script-file heuristic, and the wrapped-capture permission-denied retry trick. Cross-linked to `ops-nix-pitfalls`.

### Skill updates (3)

3. **`jira-integration` → REST-first explicit.** Promoted Direct REST API to Option A (default), demoted MCP to Option B (alternative when already configured). Top-of-skill block quotes the `agent-defaults.md` policy verbatim.

4. **`cache-scan` → "Why those logs exist" pointer.** Added a paragraph telling future sessions the logs are populated automatically by the PostToolUse hook ([common.nix:228-239](home-manager/common.nix#L228-L239) + [log-bash.sh](home-manager/local/bin/log-bash.sh)). Names the read-side companion workflow.

5. **`systematic-debugging` → Phase 0 "Check the Log First."** New phase before Phase 1. Codifies the `agent-defaults.md:10` rule: before retrying a failed command, grep `~/.cache/<agent>/*.log` for prior successful invocations and use them as templates. Pairs with the `cache-scan` doc update — that skill produces the index, this phase consumes it.

### Declined per the plan

- The `log-bash.sh` hook itself — plumbing, fires automatically, no LLM decision surface. Made *discoverable* via the `cache-scan` update instead.
- `ops-nix-pitfalls` as a sink for shell pitfalls — moot since `shell-pitfalls` landed as a standalone skill.

## Sequencing note (read this before merging)

The new skills use **post-rename paths** (`sec-sops-encrypt`, `flow-systematic-debugging`, etc.) per the prefix-categorization plan. Those targets exist on the open rename PRs but not yet on `main`. **This PR should merge AFTER all six rename PRs (#30-#35) to keep cross-references valid.**

If a rename PR is dropped, the references in this PR will need a follow-up edit; the most likely candidates are:
- `[sec-sops-encrypt](../sec-sops-encrypt/...)` in `sec-credentials/SKILL.md` and `jira-integration/SKILL.md`
- `[ops-nix-pitfalls](../ops-nix-pitfalls/SKILL.md)` in `shell-pitfalls/SKILL.md`
- `[flow-systematic-debugging](../flow-systematic-debugging/SKILL.md)` in `cache-scan/SKILL.md`

After this PR also lands, three of the post-rename skills get *new* cross-references that the rename PRs themselves don't include. When everything is merged, the result is a skill graph where every `/sec-*`, `/ops-*`, `/flow-*` skill names its neighbors by their prefixed names.

## Test plan

- [ ] `task lint:nix` passes (verified locally)
- [ ] `/sec-credentials` and `/shell-pitfalls` resolve in Claude Code on next session
- [ ] When a session asks "where's the Jira token", `sec-credentials` triggers and points to the sops-decrypted path
- [ ] When a session encounters a heavily-quoted shell failure, `shell-pitfalls` triggers
- [ ] When a session encounters a failing command, `systematic-debugging` Phase 0 fires before Phase 1 and recommends `rg -l ... ~/.cache/<agent>/*.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)