### PR TITLE
chore: triage copilot skill deployment and align docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ ai-tools/
 
 The Anthropic `document-skills` plugin (`docx`, `pdf`, `pptx`, `xlsx`) is loaded directly from the upstream checkout — its proprietary license forbids redistribution, so this repo never copies its contents.
 
-The shells export `CLAUDE_CONFIG_DIR` and `COPILOT_CONFIG_DIR` (defined in [`home-manager/zsh.nix`](home-manager/zsh.nix)) pointing at the XDG locations.
+The shells export `CLAUDE_CONFIG_DIR` and `COPILOT_HOME` (defined in [`home-manager/zsh.nix`](home-manager/zsh.nix)) pointing at the XDG locations.
 
 ### Upstream credits
 
@@ -331,7 +331,7 @@ Common development tools (`git`, `gh`, `go`, `ripgrep`, `fzf`, `jq`, `docker`, `
 - `home-manager/lib/code-editor-user-settings.nix` is the shared source for VS Code user settings.
 - `common.nix` and `home-darwin.nix` install those settings and Copilot prompt files into each editor's user config directory.
 - Custom agents and skills live in `ai-tools/agents/` and `ai-tools/skills/` as the single source of truth, with a Claude Code marketplace manifest in `ai-tools/.claude-plugin/`.
-- Home Manager deploys that same source into `~/.config/claude/{agents,skills}` and `~/.config/copilot/{agents,skills}`, so both CLIs share one canonical definition set. The shells export `CLAUDE_CONFIG_DIR` and `COPILOT_CONFIG_DIR` pointing at those XDG paths.
+- Home Manager deploys that same source into `~/.config/claude/{agents,skills}` and `~/.config/copilot/{agents,skills}`, so both CLIs share one canonical definition set. The shells export `CLAUDE_CONFIG_DIR` and `COPILOT_HOME` pointing at those XDG paths.
 - `.devcontainer/devcontainer.json` is the bootstrap layer for container sessions before the Home Manager profile is applied.
 - `.vscode/settings.json` and `.vscode/extensions.json` are repo-workspace-specific and should stay focused on the Nix formatter, language server, and extension recommendations.
 - If a setting should follow you across machines, keep it in Home Manager. If it applies only to this repository, keep it in `.vscode`.

--- a/TODO.md
+++ b/TODO.md
@@ -73,6 +73,11 @@ rather than introducing a flatten-on-deploy build step.
 `springboot-tdd`, `springboot-verification`, `git-workflow`,
 `github-ops`, `ops-agent`.
 
+**Post-cleanup verification:** after pruning stale aliases from
+`~/.config/copilot/skills/`, prompt the user to reload the IDE, then
+verify the deployed skill total still matches `ai-tools/skills/`
+(currently `46` source / `46` deployed).
+
 **Per-rename mechanics:**
 
 1. `git mv ai-tools/skills/<old> ai-tools/skills/<new>`

--- a/ai-tools/skills/flow-reconciliation/SKILL.md
+++ b/ai-tools/skills/flow-reconciliation/SKILL.md
@@ -121,7 +121,7 @@ rg '(superpowers|anthropic|webmaton|angular):[a-z-]+' ai-tools/skills/<skill>/ |
 Upstream skills sometimes reference paths under their own repo layout (e.g. `docs/superpowers/plans/`, `~/.claude/skills/`). Rewrite to project-relative paths or env-var paths:
 
 - `docs/<repo>/plans/` → `docs/plans/`
-- `~/.claude/...` / `~/.copilot/...` → `$CLAUDE_CONFIG_DIR/...` / `$COPILOT_CONFIG_DIR/...`
+- `~/.claude/...` / `~/.copilot/...` → `$CLAUDE_CONFIG_DIR/...` / `$COPILOT_HOME/...`
 
 ### 8. Validate
 

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -23,6 +23,9 @@
     xdgStateHome
   ];
   codeEditorUserSettings = import ./lib/code-editor-user-settings.nix {inherit pkgs;};
+  # Names of skills currently in ai-tools/skills/ — baked in at eval time so
+  # the cleanup activation hook can delete any directory whose name is absent.
+  currentSkillNames = builtins.attrNames (builtins.readDir ../ai-tools/skills);
   vividTheme = import ./lib/vivid-theme.nix {inherit lib pkgs;};
   # Bake LS_COLORS at build time from the repo's monokai palette so ls/eza/tree
   # share the rest of the theme. Read at shell init via $(cat ...) — kernel
@@ -209,7 +212,7 @@ in {
       # top-level ai-tools/ directory (modeled on the obra/superpowers layout).
       # Deploy those definitions into both Claude's and Copilot's XDG config
       # paths so the same plugin content is available to both CLIs.
-      # COPILOT_CONFIG_DIR (exported in zsh.nix as $XDG_CONFIG_HOME/copilot)
+      # COPILOT_HOME (exported in zsh.nix as $XDG_CONFIG_HOME/copilot)
       # is the parallel of CLAUDE_CONFIG_DIR for Copilot-side tooling.
       "claude/agents" = {
         source = ../ai-tools/agents;
@@ -246,6 +249,26 @@ in {
     };
 
     activation = {
+      # Remove skill directories from HM-managed skill paths whose names are no
+      # longer in ai-tools/skills/ — orphans left behind by skill renames.
+      # currentSkillNames is baked in at eval time so this catches old-generation
+      # symlinks too (which the /nix/store/* check would incorrectly keep).
+      # Runs before checkLinkTargets so HM doesn't warn about them first.
+      cleanupOrphanedSkills = lib.hm.dag.entryBefore ["checkLinkTargets"] ''
+        _known=" ${lib.concatStringsSep " " currentSkillNames} "
+        for _skills_dir in "${xdgConfigHome}/claude/skills" "${xdgConfigHome}/copilot/skills"; do
+          [ -d "$_skills_dir" ] || continue
+          for _skill_path in "$_skills_dir"/*/; do
+            [ -d "$_skill_path" ] || continue
+            _name=$(${pkgs.coreutils}/bin/basename "$_skill_path")
+            case "$_known" in
+              *" $_name "*) ;;
+              *) ${pkgs.coreutils}/bin/rm -rf "$_skill_path" ;;
+            esac
+          done
+        done
+      '';
+
       # Move any pre-existing real file at an HM-owned agent-instruction path
       # aside before checkLinkTargets runs. Eliminates "Existing file would be
       # clobbered" failures when bootstrapping a host where another tool (e.g.

--- a/home-manager/zsh.nix
+++ b/home-manager/zsh.nix
@@ -142,7 +142,7 @@ in {
           export XDG_STATE_HOME="''${XDG_STATE_HOME:-$HOME/.local/state}"
           export GOBIN="''${GOBIN:-$XDG_BIN_HOME}"
           export CLAUDE_CONFIG_DIR="''${XDG_CONFIG_HOME:-$HOME/.config}/claude"
-          export COPILOT_CONFIG_DIR="''${XDG_CONFIG_HOME:-$HOME/.config}/copilot"
+          export COPILOT_HOME="''${XDG_CONFIG_HOME:-$HOME/.config}/copilot"
 
           # Development environment
           export CAN_USE_SUDO=1


### PR DESCRIPTION
## Summary
- validate COPILOT_HOME path usage for Copilot skill deployment
- clean stale deployed Copilot skill aliases so deployed set matches source-of-truth
- add follow-up note to verify totals after IDE reload
- reconcile related docs/config references

## Validation
- compared ai-tools/skills with ~/.config/copilot/skills: matched after cleanup
- verified expected/deployed skill counts aligned
