### PR TITLE
feat(copilot): bridge Claude skills and agents into VS Code prompt dirs

### DIFF
--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -150,8 +150,7 @@
     lsof
   ];
   agentInstructions = import ./lib/agent-instructions.nix {inherit pkgs;};
-  copilotDefaultsFile = agentInstructions.copilot;
-  claudeDefaultsFile = agentInstructions.claude;
+  inherit (agentInstructions) claude copilot copilotAgentBridgeDir copilotSkillBridgeDir;
   # Home-manager-managed agent-instruction destinations (paths relative to $HOME).
   # Single list keeps the home.file refactor and the orphan-backup activation
   # hook below pointing at the same set of files.
@@ -161,12 +160,18 @@
     ".config/github-copilot/copilot-defaults.instructions.md"
     ".config/github-copilot/intellij/global-copilot-instructions.md"
   ];
+  copilotInstructionDirPaths = [
+    ".config/Code/User/prompts/skills"
+    ".config/Code/User/prompts/agents"
+    ".vscode-server/data/User/prompts/skills"
+    ".vscode-server/data/User/prompts/agents"
+  ];
   agentInstructionDestPaths =
     [
       "${xdgConfigHome}/claude/CLAUDE.md"
       "${homeDirectory}/.claude/CLAUDE.md"
     ]
-    ++ map (p: "${homeDirectory}/${p}") copilotInstructionPaths;
+    ++ map (p: "${homeDirectory}/${p}") (copilotInstructionPaths ++ copilotInstructionDirPaths);
   opsAgentPython = pkgs.python3.withPackages (ps: [ps.anthropic]);
   opsAgent = pkgs.writeShellScriptBin "ops-agent" ''
     exec ${opsAgentPython}/bin/python ${./local/bin/ops-agent.py} "$@"
@@ -203,7 +208,7 @@ in {
       # pre-existing real file at the destination is moved aside by the
       # backupAgentInstructions activation hook below before this is written.
       "claude/CLAUDE.md" = {
-        source = claudeDefaultsFile;
+        source = claude;
         force = true;
       };
       "claude/log-bash.sh".source = ./local/bin/log-bash.sh;
@@ -424,9 +429,31 @@ in {
     # file aside before write.
     file =
       (lib.genAttrs copilotInstructionPaths (_: {
-        source = copilotDefaultsFile;
+        source = copilot;
         force = true;
       }))
+      // {
+        ".config/Code/User/prompts/skills" = {
+          source = copilotSkillBridgeDir;
+          recursive = true;
+          force = true;
+        };
+        ".config/Code/User/prompts/agents" = {
+          source = copilotAgentBridgeDir;
+          recursive = true;
+          force = true;
+        };
+        ".vscode-server/data/User/prompts/skills" = {
+          source = copilotSkillBridgeDir;
+          recursive = true;
+          force = true;
+        };
+        ".vscode-server/data/User/prompts/agents" = {
+          source = copilotAgentBridgeDir;
+          recursive = true;
+          force = true;
+        };
+      }
       // {
         # Claude Code's memory-file loader hardcodes ~/.claude/CLAUDE.md and
         # does not honor CLAUDE_CONFIG_DIR — see
@@ -438,7 +465,7 @@ in {
         # the loader can find. Revisit and remove this entry once the upstream
         # fix lands.
         ".claude/CLAUDE.md" = {
-          source = claudeDefaultsFile;
+          source = claude;
           force = true;
         };
       };

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -150,7 +150,7 @@
     lsof
   ];
   agentInstructions = import ./lib/agent-instructions.nix {inherit pkgs;};
-  inherit (agentInstructions) claude copilot copilotAgentBridgeDir copilotSkillBridgeDir;
+  inherit (agentInstructions) claude copilot copilotAgentBridgeDir copilotSkillBridgeDir copilotPluginManifestDir;
   # Home-manager-managed agent-instruction destinations (paths relative to $HOME).
   # Single list keeps the home.file refactor and the orphan-backup activation
   # hook below pointing at the same set of files.
@@ -450,6 +450,11 @@ in {
         };
         ".vscode-server/data/User/prompts/agents" = {
           source = copilotAgentBridgeDir;
+          recursive = true;
+          force = true;
+        };
+        ".config/copilot/plugin-manifest" = {
+          source = copilotPluginManifestDir;
           recursive = true;
           force = true;
         };

--- a/home-manager/home-darwin.nix
+++ b/home-manager/home-darwin.nix
@@ -240,7 +240,23 @@ in {
     # user configuration directories for the stable and Insiders VS Code apps.
     file = {
       "Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md".source = agentInstructions.copilot;
+      "Library/Application Support/Code/User/prompts/skills" = {
+        source = agentInstructions.copilotSkillBridgeDir;
+        recursive = true;
+      };
+      "Library/Application Support/Code/User/prompts/agents" = {
+        source = agentInstructions.copilotAgentBridgeDir;
+        recursive = true;
+      };
       "Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md".source = agentInstructions.copilot;
+      "Library/Application Support/Code - Insiders/User/prompts/skills" = {
+        source = agentInstructions.copilotSkillBridgeDir;
+        recursive = true;
+      };
+      "Library/Application Support/Code - Insiders/User/prompts/agents" = {
+        source = agentInstructions.copilotAgentBridgeDir;
+        recursive = true;
+      };
       "Library/Application Support/Code - Insiders/User/settings.json".text = builtins.toJSON codeEditorUserSettings;
     };
   };

--- a/home-manager/lib/agent-instructions.nix
+++ b/home-manager/lib/agent-instructions.nix
@@ -29,6 +29,56 @@
 in {
   inherit source render;
 
+  # Generate one Copilot prompt file per skill so VS Code prompt discovery can
+  # see the same rule content without changing the Claude plugin structure.
+  copilotSkillBridgeDir = pkgs.runCommand "copilot-skill-bridge-prompts" {} ''
+    mkdir -p "$out"
+    skills_root='${../../ai-tools/skills}'
+
+    for skill_dir in "$skills_root"/*; do
+      [ -d "$skill_dir" ] || continue
+      skill_name=$(basename "$skill_dir")
+      skill_file="$skill_dir/SKILL.md"
+      [ -f "$skill_file" ] || continue
+
+      out_file="$out/$skill_name.instructions.md"
+      {
+        printf -- '---\n'
+        printf 'description: "Copilot bridge for ai-tools/skills/%s/SKILL.md"\n' "$skill_name"
+        printf 'name: "Skill Bridge - %s"\n' "$skill_name"
+        printf 'applyTo: "**"\n'
+        printf -- '---\n\n'
+        printf '# Skill Bridge: %s\n\n' "$skill_name"
+        printf 'Source: ai-tools/skills/%s/SKILL.md\n\n' "$skill_name"
+        cat "$skill_file"
+      } > "$out_file"
+    done
+  '';
+
+  # Generate one Copilot prompt file per agent so VS Code prompt discovery can
+  # apply agent guidance even without first-class agent marketplace support.
+  copilotAgentBridgeDir = pkgs.runCommand "copilot-agent-bridge-prompts" {} ''
+    mkdir -p "$out"
+    agents_root='${../../ai-tools/agents}'
+
+    for agent_file in "$agents_root"/*.agent.md; do
+      [ -f "$agent_file" ] || continue
+      agent_name=$(basename "$agent_file" .agent.md)
+      out_file="$out/$agent_name.instructions.md"
+
+      {
+        printf -- '---\n'
+        printf 'description: "Copilot bridge for ai-tools/agents/%s.agent.md"\n' "$agent_name"
+        printf 'name: "Agent Bridge - %s"\n' "$agent_name"
+        printf 'applyTo: "**"\n'
+        printf -- '---\n\n'
+        printf '# Agent Bridge: %s\n\n' "$agent_name"
+        printf 'Source: ai-tools/agents/%s.agent.md\n\n' "$agent_name"
+        cat "$agent_file"
+      } > "$out_file"
+    done
+  '';
+
   copilot = render {
     agentName = "copilot";
     withFrontmatter = true;

--- a/home-manager/lib/agent-instructions.nix
+++ b/home-manager/lib/agent-instructions.nix
@@ -79,6 +79,94 @@ in {
     done
   '';
 
+  # Generate a Copilot plugin marketplace manifest and per-plugin metadata
+  # from the existing ai-tools/skills and ai-tools/agents source trees.
+  # Output layout mirrors the awesome-copilot plugin registry format:
+  #   marketplace.json          — root registry consumed by `copilot plugin`
+  #   skills/<name>/plugin.json — per-skill metadata
+  #   agents/<name>/plugin.json — per-agent metadata
+  copilotPluginManifestDir =
+    pkgs.runCommand "copilot-plugin-manifest" {
+      nativeBuildInputs = [pkgs.jq];
+    } ''
+      mkdir -p "$out"
+      skills_root='${../../ai-tools/skills}'
+      agents_root='${../../ai-tools/agents}'
+
+      # Extract a scalar value from the first YAML frontmatter block.
+      # Strips surrounding single or double quotes from the value.
+      extract_field() {
+        local field="$1" file="$2"
+        awk -v f="$field" '
+          /^---/ { found++; next }
+          found == 1 && $0 ~ "^" f ": " {
+            sub("^" f ": *", "")
+            gsub(/^'"'"'|'"'"'$|^"|"$/, "")
+            print; exit
+          }
+          found >= 2 { exit }
+        ' "$file"
+      }
+
+      marketplace_entries='[]'
+
+      for skill_dir in "$skills_root"/*; do
+        [ -d "$skill_dir" ] || continue
+        skill_name=$(basename "$skill_dir")
+        skill_file="$skill_dir/SKILL.md"
+        [ -f "$skill_file" ] || continue
+
+        mkdir -p "$out/skills/$skill_name"
+        skill_description=$(extract_field description "$skill_file")
+
+        jq -n \
+          --arg name "$skill_name" \
+          --arg description "$skill_description" \
+          '{name: $name, description: $description, version: "1.0.0",
+            skills: [("./skills/" + $name)]}' \
+          > "$out/skills/$skill_name/plugin.json"
+
+        marketplace_entries=$(jq -n \
+          --argjson existing "$marketplace_entries" \
+          --arg name "$skill_name" \
+          --arg description "$skill_description" \
+          '$existing + [{name: $name,
+                          source: ("./skills/" + $name),
+                          description: $description,
+                          version: "1.0.0",
+                          type: "skill"}]')
+      done
+
+      for agent_file in "$agents_root"/*.agent.md; do
+        [ -f "$agent_file" ] || continue
+        agent_name=$(basename "$agent_file" .agent.md)
+
+        mkdir -p "$out/agents/$agent_name"
+        agent_description=$(extract_field description "$agent_file")
+
+        jq -n \
+          --arg name "$agent_name" \
+          --arg description "$agent_description" \
+          '{name: $name, description: $description, version: "1.0.0",
+            type: "agent",
+            tools: ["codebase", "edit/editFiles", "fetch", "search"]}' \
+          > "$out/agents/$agent_name/plugin.json"
+
+        marketplace_entries=$(jq -n \
+          --argjson existing "$marketplace_entries" \
+          --arg name "$agent_name" \
+          --arg description "$agent_description" \
+          '$existing + [{name: $name,
+                          source: ("./agents/" + $name),
+                          description: $description,
+                          version: "1.0.0",
+                          type: "agent"}]')
+      done
+
+      jq -n --argjson plugins "$marketplace_entries" \
+        '{plugins: $plugins}' > "$out/marketplace.json"
+    '';
+
   copilot = render {
     agentName = "copilot";
     withFrontmatter = true;


### PR DESCRIPTION
## Summary

- Add `copilotSkillBridgeDir` and `copilotAgentBridgeDir` derivations in `agent-instructions.nix` that generate per-skill and per-agent Copilot instruction files at build time via `pkgs.runCommand`
- Wire the generated directories into `home.file` in `common.nix` covering Linux XDG and WSL paths (skills and agents under `.config/Code/User/prompts/` and `.vscode-server/data/User/prompts/`)
- Add the same bridge dirs to `home-darwin.nix` for macOS VS Code and VS Code Insiders paths under `Library/Application Support/Code*/User/prompts/`

## Test Plan

- [x] `task fmt:check` — alejandra reports no style issues
- [x] `task lint:nix` — statix, deadnix, copilot-instructions sync, and agent-instructions checks all pass
- [x] Pre-commit hooks pass (lint + gitleaks)
- [ ] Verify `~/.config/Code/User/prompts/skills/` and `agents/` are populated after `task home-switch`
- [ ] Confirm VS Code Copilot picks up the generated instruction files in prompt discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)