### PR TITLE
fix(copilot): convert skill/agent bridges from instructions to prompt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,14 +279,26 @@ ai-tools/
 ├── .claude-plugin/
 │   ├── marketplace.json     # registers nix-config-tools as a Claude Code plugin
 │   └── plugin.json          # plugin metadata
-├── agents/                  # *.agent.md
+├── agents/                  # *.agent.md — four custom sub-agents
 └── skills/                  # <name>/SKILL.md (+ optional references/, scripts/)
 ```
 
-[`home-manager/common.nix`](home-manager/common.nix) deploys this content into both
-`~/.config/claude/{skills,agents}` and `~/.config/copilot/{skills,agents}`, and the `registerClaudeMarketplaces`
-activation hook idempotently writes the marketplace registration into `~/.config/claude/settings.json`. Two
-marketplaces are registered:
+[`home-manager/lib/agent-instructions.nix`](home-manager/lib/agent-instructions.nix) generates bridge files and
+[`home-manager/common.nix`](home-manager/common.nix) deploys them:
+
+| Destination | File type | Frontmatter | Behaviour |
+|---|---|---|---|
+| `~/.config/claude/{skills,agents}` | raw `SKILL.md` / `*.agent.md` | as-authored | loaded by Claude Code marketplace |
+| `~/.config/copilot/{skills,agents}` | raw `SKILL.md` / `*.agent.md` | as-authored | loaded by Copilot CLI |
+| `prompts/skills/*.prompt.md` | generated bridge | `mode: ask` | invoke on-demand in VS Code Copilot Chat with `/` |
+| `prompts/agents/*.prompt.md` | generated bridge | `mode: agent` | invoke on-demand in VS Code Copilot Chat with `/` |
+
+Skills and agents are **not** deployed as always-on instruction files — only `copilot-defaults.instructions.md`
+carries `applyTo: "**"`. This keeps the active instruction count to one and makes each skill or agent available
+as an explicit slash command (e.g. `/flow-test-driven-development`, `/github-actions-expert`).
+
+The `registerClaudeMarketplaces` activation hook idempotently writes the marketplace registration into
+`~/.config/claude/settings.json`. Two marketplaces are registered:
 
 | Marketplace | Source | Plugins enabled |
 |---|---|---|
@@ -368,9 +380,10 @@ Common development tools (`git`, `gh`, `go`, `ripgrep`, `fzf`, `jq`, `docker`, `
 - `common.nix` and `home-darwin.nix` install those settings and Copilot prompt files into each editor's user config directory.
 - Custom agents and skills live in `ai-tools/agents/` and `ai-tools/skills/` as the single source of truth, with a
   Claude Code marketplace manifest in `ai-tools/.claude-plugin/`.
-- Home Manager deploys that same source into `~/.config/claude/{agents,skills}` and
-  `~/.config/copilot/{agents,skills}`, so both CLIs share one canonical definition set. The shells export
-  `CLAUDE_CONFIG_DIR` and `COPILOT_HOME` pointing at those XDG paths.
+- Home Manager deploys skills and agents to `~/.config/claude/{agents,skills}` and `~/.config/copilot/{agents,skills}`
+  for Claude Code and the Copilot CLI. For VS Code Copilot Chat, generated `*.prompt.md` bridges are installed under
+  `prompts/skills/` and `prompts/agents/` — available on-demand via `/` rather than as always-on instructions. The
+  shells export `CLAUDE_CONFIG_DIR` and `COPILOT_HOME` pointing at those XDG paths.
 - `.devcontainer/devcontainer.json` is the bootstrap layer for container sessions before the Home Manager profile is
   applied.
 - `.vscode/settings.json` and `.vscode/extensions.json` are repo-workspace-specific and should stay focused on the Nix

--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777851538,
-        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
+        "lastModified": 1778401693,
+        "narHash": "sha256-OVHdCqXXUF5UdGkH+FF2ZL06OLZjj2kvP2dIUmzVWoo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
+        "rev": "389b83002efc26f1145e89a6a8e6edc5a6435948",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
         "type": "github"
       },
       "original": {

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -301,6 +301,22 @@ in {
         done
       '';
 
+      # Remove stale *.instructions.md files from skill/agent bridge prompt
+      # directories.  These were produced by older generations before the bridge
+      # generators switched to *.prompt.md; without this hook they persist
+      # alongside the new prompt files and re-inflate the instruction count.
+      cleanupStaleInstructionBridges = lib.hm.dag.entryBefore ["checkLinkTargets"] ''
+        for _dir in ${lib.concatMapStringsSep " " lib.escapeShellArg (
+          map (p: "${homeDirectory}/${p}") copilotInstructionDirPaths
+        )}; do
+          [ -d "$_dir" ] || continue
+          for _f in "$_dir"/*.instructions.md; do
+            [ -f "$_f" ] || [ -L "$_f" ] || continue
+            ${pkgs.coreutils}/bin/rm -f "$_f"
+          done
+        done
+      '';
+
       # Move any pre-existing real file at an HM-owned agent-instruction path
       # aside before checkLinkTargets runs. Eliminates "Existing file would be
       # clobbered" failures when bootstrapping a host where another tool (e.g.

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -342,6 +342,11 @@ in {
             '.hooks.PostToolUse |= (. // []) + [{"matcher":"Bash","hooks":[{"type":"command","command":"AGENT_NAME=claude bash \"''${CLAUDE_CONFIG_DIR:-$HOME/.config/claude}/log-bash.sh\"","async":true}]}]' \
             "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
         fi
+        if ! jq -e '.attribution' "$_settings" > /dev/null 2>&1; then
+          _tmp=$(${pkgs.coreutils}/bin/mktemp)
+          jq '.attribution = {"commit": "", "pr": ""}' \
+            "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
+        fi
       '';
 
       # Register Claude Code marketplaces in ~/.config/claude/settings.json:

--- a/home-manager/home-darwin.nix
+++ b/home-manager/home-darwin.nix
@@ -142,6 +142,23 @@ in {
     sessionVariables.BROWSER = "vivaldi";
 
     activation = {
+      # Remove stale *.instructions.md files from macOS skill/agent bridge
+      # prompt directories left behind by older generations before the bridge
+      # generators switched to *.prompt.md.
+      cleanupStaleInstructionBridgesDarwin = lib.hm.dag.entryBefore ["checkLinkTargets"] ''
+        for _dir in \
+          "$HOME/Library/Application Support/Code/User/prompts/skills" \
+          "$HOME/Library/Application Support/Code/User/prompts/agents" \
+          "$HOME/Library/Application Support/Code - Insiders/User/prompts/skills" \
+          "$HOME/Library/Application Support/Code - Insiders/User/prompts/agents"; do
+          [ -d "$_dir" ] || continue
+          for _f in "$_dir"/*.instructions.md; do
+            [ -f "$_f" ] || [ -L "$_f" ] || continue
+            ${pkgs.coreutils}/bin/rm -f "$_f"
+          done
+        done
+      '';
+
       # Install SDKMAN! on macOS so Java toolchains can be managed declaratively
       installSdkman = lib.hm.dag.entryAfter ["writeBoundary"] ''
         sdkman_dir="$HOME/.sdkman"

--- a/home-manager/lib/agent-instructions.nix
+++ b/home-manager/lib/agent-instructions.nix
@@ -41,12 +41,12 @@ in {
       skill_file="$skill_dir/SKILL.md"
       [ -f "$skill_file" ] || continue
 
-      out_file="$out/$skill_name.instructions.md"
+      out_file="$out/$skill_name.prompt.md"
       {
         printf -- '---\n'
         printf 'description: "Copilot bridge for ai-tools/skills/%s/SKILL.md"\n' "$skill_name"
         printf 'name: "Skill Bridge - %s"\n' "$skill_name"
-        printf 'applyTo: "**"\n'
+        printf 'mode: ask\n'
         printf -- '---\n\n'
         printf '# Skill Bridge: %s\n\n' "$skill_name"
         printf 'Source: ai-tools/skills/%s/SKILL.md\n\n' "$skill_name"
@@ -64,13 +64,13 @@ in {
     for agent_file in "$agents_root"/*.agent.md; do
       [ -f "$agent_file" ] || continue
       agent_name=$(basename "$agent_file" .agent.md)
-      out_file="$out/$agent_name.instructions.md"
+      out_file="$out/$agent_name.prompt.md"
 
       {
         printf -- '---\n'
         printf 'description: "Copilot bridge for ai-tools/agents/%s.agent.md"\n' "$agent_name"
         printf 'name: "Agent Bridge - %s"\n' "$agent_name"
-        printf 'applyTo: "**"\n'
+        printf 'mode: agent\n'
         printf -- '---\n\n'
         printf '# Agent Bridge: %s\n\n' "$agent_name"
         printf 'Source: ai-tools/agents/%s.agent.md\n\n' "$agent_name"


### PR DESCRIPTION
## Problem

Skills and agents were being deployed as `*.instructions.md` files with `applyTo: '**'`, which loaded all 64 skills + 4 agents as always-on instructions — ballooning the instruction count to ~70.

## Fix

This PR cherry-picks commit `89d05ab` (originally in a separate worktree branch) and adds the staged `main` changes (flake.lock update + claude attribution setting):

- **`agent-instructions.nix`**: `copilotSkillBridgeDir` now emits `*.prompt.md` with `mode: ask` instead of `*.instructions.md` with `applyTo: '**'`
- **`agent-instructions.nix`**: `copilotAgentBridgeDir` now emits `*.prompt.md` with `mode: agent`
- **`common.nix`**: Adds `cleanupStaleInstructionBridges` activation hook to remove old `*.instructions.md` files on Linux/WSL
- **`home-darwin.nix`**: Adds `cleanupStaleInstructionBridgesDarwin` activation hook for macOS Library paths
- **`home-manager/common.nix`**: Staged attribution setting for Claude
- **`flake.lock`**: Updated lock file

## Result

After `home-manager switch`:
- Only `copilot-defaults.instructions.md` remains as an always-on instruction (1 instruction total)
- All 64 skills and 4 agents are available on-demand in VS Code Copilot Chat via `/`