### PR TITLE
feat(ops): add Copilot bash logging hook and fix switch noise

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,17 @@
   Bash before reading. Do not decompress speculatively; only decompress when
   uncompressed logs contain no useful example.
 - When looking for tool credentials, auth state, or cached session data, examine
-  `~/.cache` first and then `~/.config`.
+  `~/.cache` first and then `~/.config`. Known locations by service:
+  - **Jira**: token at `~/.config/ops-agent/jira-token`, base URL at
+    `~/.config/ops-agent/jira-base-url` (SOPS-decrypted from
+    `secrets/ops-agent.yaml` in the nix-config repo)
+  - **Confluence**: token at `~/.config/confluence/token`, base URL at
+    `~/.config/confluence/base-url` (same SOPS source)
+  - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
+    `~/.cache/kion-aws-cache/`
+  - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
+  - **SOPS age key** (decrypts all nix-managed secrets):
+    `~/.config/sops/age/keys.txt`
 - For Jira and Confluence operations, prefer direct REST/API-spec requests with
   configured tokens over dedicated `jira-cli` or `confluence-cli` wrappers.
 - For GitHub repository, issue, release, and pull request operations, prefer
@@ -63,3 +73,39 @@
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under `~/.cache/copilot` and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Agent Instruction Sources
+
+This file (`chezmoi/dot_config/instructions/agent-defaults.md`) is the single
+source of truth for persistent agent defaults. It is rendered by
+`home-manager/lib/agent-instructions.nix` (substituting `copilot` with the
+agent name) and deployed as read-only symlinks via home-manager. Each deployed
+file is loaded into the agent session's system prompt at startup and is the
+primary source of Anthropic prompt-cache hits for that session.
+
+Stable deployment paths — these symlinks always point to the active generation:
+
+**Claude** (loaded via `CLAUDE_CONFIG_DIR` or fallback):
+
+- `~/.config/claude/CLAUDE.md` — primary
+- `~/.claude/CLAUDE.md` — fallback / memory resolution path
+
+**Copilot:**
+
+- `~/.config/github-copilot/copilot-defaults.instructions.md` — Copilot CLI
+- `~/Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md` — VS Code stable (macOS)
+- `~/Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md` — VS Code Insiders (macOS)
+- `~/.config/Code/User/prompts/copilot-defaults.instructions.md` — VS Code (Linux/XDG)
+- `~/.vscode-server/data/User/prompts/copilot-defaults.instructions.md` — VS Code Server
+
+Each symlink resolves through the current home-manager generation bundle in the
+nix store. To find the active nix store path for a given agent:
+
+```sh
+readlink -f ~/.config/claude/CLAUDE.md          # Claude variant
+readlink -f ~/.config/github-copilot/copilot-defaults.instructions.md  # Copilot variant
+```
+
+The chezmoi path for this file (`chezmoi/dot_config/instructions/`) makes the
+credential and cache-directory locations documented above discoverable on hosts
+that have chezmoi but not the full nix config.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,18 @@
   - **Confluence**: token at `~/.config/confluence/token`, base URL at
     `~/.config/confluence/base-url` (same SOPS source)
   - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
-    `~/.cache/kion-aws-cache/`
+    `~/.cache/kion-aws-cache/`. Credentials in `~/.aws/credentials` and
+    `AWS_PROFILE` are frequently stale and produce `ExpiredTokenException`.
+    Prefer loading directly from the Kion cache:
+
+    ```sh
+    export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
+    export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
+    export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
+    ```
+
+    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
+    refresh via `kion s` if the cache is empty.
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`

--- a/chezmoi/dot_claude/settings.json
+++ b/chezmoi/dot_claude/settings.json
@@ -1,5 +1,14 @@
 {
     "model": "opus",
+    "mcpServers": {
+        "aws-api": {
+            "type": "stdio",
+            "command": "$HOME/.local/bin/aws-mcp-server",
+            "env": {
+                "AWS_REGION": "us-east-1"
+            }
+        }
+    },
     "permissions": {
         "allow": [
             "Bash(gh pr *)",

--- a/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
@@ -26,7 +26,17 @@ applyTo: "**"
   Bash before reading. Do not decompress speculatively; only decompress when
   uncompressed logs contain no useful example.
 - When looking for tool credentials, auth state, or cached session data, examine
-  ~/.cache first and then ~/.config.
+  ~/.cache first and then ~/.config. Known locations by service:
+  - **Jira**: token at `~/.config/ops-agent/jira-token`, base URL at
+    `~/.config/ops-agent/jira-base-url` (SOPS-decrypted from
+    `secrets/ops-agent.yaml` in the nix-config repo)
+  - **Confluence**: token at `~/.config/confluence/token`, base URL at
+    `~/.config/confluence/base-url` (same SOPS source)
+  - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
+    `~/.cache/kion-aws-cache/`
+  - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
+  - **SOPS age key** (decrypts all nix-managed secrets):
+    `~/.config/sops/age/keys.txt`
 - For Jira and Confluence operations, prefer direct REST/API-spec requests with
   configured tokens over dedicated `jira-cli` or `confluence-cli` wrappers.
 - For GitHub repository, issue, release, and pull request operations, prefer
@@ -66,3 +76,39 @@ applyTo: "**"
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Agent Instruction Sources
+
+This file (`chezmoi/dot_config/instructions/agent-defaults.md`) is the single
+source of truth for persistent agent defaults. It is rendered by
+`home-manager/lib/agent-instructions.nix` (substituting `copilot` with the
+agent name) and deployed as read-only symlinks via home-manager. Each deployed
+file is loaded into the agent session's system prompt at startup and is the
+primary source of Anthropic prompt-cache hits for that session.
+
+Stable deployment paths — these symlinks always point to the active generation:
+
+**Claude** (loaded via `CLAUDE_CONFIG_DIR` or fallback):
+
+- `~/.config/claude/CLAUDE.md` — primary
+- `~/.claude/CLAUDE.md` — fallback / memory resolution path
+
+**Copilot:**
+
+- `~/.config/github-copilot/copilot-defaults.instructions.md` — Copilot CLI
+- `~/Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md` — VS Code stable (macOS)
+- `~/Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md` — VS Code Insiders (macOS)
+- `~/.config/Code/User/prompts/copilot-defaults.instructions.md` — VS Code (Linux/XDG)
+- `~/.vscode-server/data/User/prompts/copilot-defaults.instructions.md` — VS Code Server
+
+Each symlink resolves through the current home-manager generation bundle in the
+nix store. To find the active nix store path for a given agent:
+
+```sh
+readlink -f ~/.config/claude/CLAUDE.md          # Claude variant
+readlink -f ~/.config/github-copilot/copilot-defaults.instructions.md  # Copilot variant
+```
+
+The chezmoi path for this file (`chezmoi/dot_config/instructions/`) makes the
+credential and cache-directory locations documented above discoverable on hosts
+that have chezmoi but not the full nix config.

--- a/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
@@ -33,7 +33,18 @@ applyTo: "**"
   - **Confluence**: token at `~/.config/confluence/token`, base URL at
     `~/.config/confluence/base-url` (same SOPS source)
   - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
-    `~/.cache/kion-aws-cache/`
+    `~/.cache/kion-aws-cache/`. Credentials in `~/.aws/credentials` and
+    `AWS_PROFILE` are frequently stale and produce `ExpiredTokenException`.
+    Prefer loading directly from the Kion cache:
+
+    ```sh
+    export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
+    export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
+    export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
+    ```
+
+    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
+    refresh via `kion s` if the cache is empty.
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`

--- a/chezmoi/dot_config/claude/CLAUDE.md
+++ b/chezmoi/dot_config/claude/CLAUDE.md
@@ -30,7 +30,18 @@
   - **Confluence**: token at `~/.config/confluence/token`, base URL at
     `~/.config/confluence/base-url` (same SOPS source)
   - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
-    `~/.cache/kion-aws-cache/`
+    `~/.cache/kion-aws-cache/`. Credentials in `~/.aws/credentials` and
+    `AWS_PROFILE` are frequently stale and produce `ExpiredTokenException`.
+    Prefer loading directly from the Kion cache:
+
+    ```sh
+    export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
+    export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
+    export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
+    ```
+
+    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
+    refresh via `kion s` if the cache is empty.
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`

--- a/chezmoi/dot_config/claude/CLAUDE.md
+++ b/chezmoi/dot_config/claude/CLAUDE.md
@@ -23,7 +23,17 @@
   Bash before reading. Do not decompress speculatively; only decompress when
   uncompressed logs contain no useful example.
 - When looking for tool credentials, auth state, or cached session data, examine
-  ~/.cache first and then ~/.config.
+  ~/.cache first and then ~/.config. Known locations by service:
+  - **Jira**: token at `~/.config/ops-agent/jira-token`, base URL at
+    `~/.config/ops-agent/jira-base-url` (SOPS-decrypted from
+    `secrets/ops-agent.yaml` in the nix-config repo)
+  - **Confluence**: token at `~/.config/confluence/token`, base URL at
+    `~/.config/confluence/base-url` (same SOPS source)
+  - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
+    `~/.cache/kion-aws-cache/`
+  - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
+  - **SOPS age key** (decrypts all nix-managed secrets):
+    `~/.config/sops/age/keys.txt`
 - For Jira and Confluence operations, prefer direct REST/API-spec requests with
   configured tokens over dedicated `jira-cli` or `confluence-cli` wrappers.
 - For GitHub repository, issue, release, and pull request operations, prefer
@@ -63,3 +73,39 @@
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Agent Instruction Sources
+
+This file (`chezmoi/dot_config/instructions/agent-defaults.md`) is the single
+source of truth for persistent agent defaults. It is rendered by
+`home-manager/lib/agent-instructions.nix` (substituting `claude` with the
+agent name) and deployed as read-only symlinks via home-manager. Each deployed
+file is loaded into the agent session's system prompt at startup and is the
+primary source of Anthropic prompt-cache hits for that session.
+
+Stable deployment paths — these symlinks always point to the active generation:
+
+**Claude** (loaded via `CLAUDE_CONFIG_DIR` or fallback):
+
+- `~/.config/claude/CLAUDE.md` — primary
+- `~/.claude/CLAUDE.md` — fallback / memory resolution path
+
+**Copilot:**
+
+- `~/.config/github-copilot/copilot-defaults.instructions.md` — Copilot CLI
+- `~/Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md` — VS Code stable (macOS)
+- `~/Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md` — VS Code Insiders (macOS)
+- `~/.config/Code/User/prompts/copilot-defaults.instructions.md` — VS Code (Linux/XDG)
+- `~/.vscode-server/data/User/prompts/copilot-defaults.instructions.md` — VS Code Server
+
+Each symlink resolves through the current home-manager generation bundle in the
+nix store. To find the active nix store path for a given agent:
+
+```sh
+readlink -f ~/.config/claude/CLAUDE.md          # Claude variant
+readlink -f ~/.config/github-copilot/copilot-defaults.instructions.md  # Copilot variant
+```
+
+The chezmoi path for this file (`chezmoi/dot_config/instructions/`) makes the
+credential and cache-directory locations documented above discoverable on hosts
+that have chezmoi but not the full nix config.

--- a/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
@@ -26,7 +26,17 @@ applyTo: "**"
   Bash before reading. Do not decompress speculatively; only decompress when
   uncompressed logs contain no useful example.
 - When looking for tool credentials, auth state, or cached session data, examine
-  ~/.cache first and then ~/.config.
+  ~/.cache first and then ~/.config. Known locations by service:
+  - **Jira**: token at `~/.config/ops-agent/jira-token`, base URL at
+    `~/.config/ops-agent/jira-base-url` (SOPS-decrypted from
+    `secrets/ops-agent.yaml` in the nix-config repo)
+  - **Confluence**: token at `~/.config/confluence/token`, base URL at
+    `~/.config/confluence/base-url` (same SOPS source)
+  - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
+    `~/.cache/kion-aws-cache/`
+  - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
+  - **SOPS age key** (decrypts all nix-managed secrets):
+    `~/.config/sops/age/keys.txt`
 - For Jira and Confluence operations, prefer direct REST/API-spec requests with
   configured tokens over dedicated `jira-cli` or `confluence-cli` wrappers.
 - For GitHub repository, issue, release, and pull request operations, prefer
@@ -66,3 +76,39 @@ applyTo: "**"
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Agent Instruction Sources
+
+This file (`chezmoi/dot_config/instructions/agent-defaults.md`) is the single
+source of truth for persistent agent defaults. It is rendered by
+`home-manager/lib/agent-instructions.nix` (substituting `copilot` with the
+agent name) and deployed as read-only symlinks via home-manager. Each deployed
+file is loaded into the agent session's system prompt at startup and is the
+primary source of Anthropic prompt-cache hits for that session.
+
+Stable deployment paths — these symlinks always point to the active generation:
+
+**Claude** (loaded via `CLAUDE_CONFIG_DIR` or fallback):
+
+- `~/.config/claude/CLAUDE.md` — primary
+- `~/.claude/CLAUDE.md` — fallback / memory resolution path
+
+**Copilot:**
+
+- `~/.config/github-copilot/copilot-defaults.instructions.md` — Copilot CLI
+- `~/Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md` — VS Code stable (macOS)
+- `~/Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md` — VS Code Insiders (macOS)
+- `~/.config/Code/User/prompts/copilot-defaults.instructions.md` — VS Code (Linux/XDG)
+- `~/.vscode-server/data/User/prompts/copilot-defaults.instructions.md` — VS Code Server
+
+Each symlink resolves through the current home-manager generation bundle in the
+nix store. To find the active nix store path for a given agent:
+
+```sh
+readlink -f ~/.config/claude/CLAUDE.md          # Claude variant
+readlink -f ~/.config/github-copilot/copilot-defaults.instructions.md  # Copilot variant
+```
+
+The chezmoi path for this file (`chezmoi/dot_config/instructions/`) makes the
+credential and cache-directory locations documented above discoverable on hosts
+that have chezmoi but not the full nix config.

--- a/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
@@ -33,7 +33,18 @@ applyTo: "**"
   - **Confluence**: token at `~/.config/confluence/token`, base URL at
     `~/.config/confluence/base-url` (same SOPS source)
   - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
-    `~/.cache/kion-aws-cache/`
+    `~/.cache/kion-aws-cache/`. Credentials in `~/.aws/credentials` and
+    `AWS_PROFILE` are frequently stale and produce `ExpiredTokenException`.
+    Prefer loading directly from the Kion cache:
+
+    ```sh
+    export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
+    export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
+    export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
+    ```
+
+    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
+    refresh via `kion s` if the cache is empty.
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`

--- a/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
+++ b/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
@@ -26,7 +26,17 @@ applyTo: "**"
   Bash before reading. Do not decompress speculatively; only decompress when
   uncompressed logs contain no useful example.
 - When looking for tool credentials, auth state, or cached session data, examine
-  ~/.cache first and then ~/.config.
+  ~/.cache first and then ~/.config. Known locations by service:
+  - **Jira**: token at `~/.config/ops-agent/jira-token`, base URL at
+    `~/.config/ops-agent/jira-base-url` (SOPS-decrypted from
+    `secrets/ops-agent.yaml` in the nix-config repo)
+  - **Confluence**: token at `~/.config/confluence/token`, base URL at
+    `~/.config/confluence/base-url` (same SOPS source)
+  - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
+    `~/.cache/kion-aws-cache/`
+  - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
+  - **SOPS age key** (decrypts all nix-managed secrets):
+    `~/.config/sops/age/keys.txt`
 - For Jira and Confluence operations, prefer direct REST/API-spec requests with
   configured tokens over dedicated `jira-cli` or `confluence-cli` wrappers.
 - For GitHub repository, issue, release, and pull request operations, prefer
@@ -66,3 +76,39 @@ applyTo: "**"
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Agent Instruction Sources
+
+This file (`chezmoi/dot_config/instructions/agent-defaults.md`) is the single
+source of truth for persistent agent defaults. It is rendered by
+`home-manager/lib/agent-instructions.nix` (substituting `copilot` with the
+agent name) and deployed as read-only symlinks via home-manager. Each deployed
+file is loaded into the agent session's system prompt at startup and is the
+primary source of Anthropic prompt-cache hits for that session.
+
+Stable deployment paths — these symlinks always point to the active generation:
+
+**Claude** (loaded via `CLAUDE_CONFIG_DIR` or fallback):
+
+- `~/.config/claude/CLAUDE.md` — primary
+- `~/.claude/CLAUDE.md` — fallback / memory resolution path
+
+**Copilot:**
+
+- `~/.config/github-copilot/copilot-defaults.instructions.md` — Copilot CLI
+- `~/Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md` — VS Code stable (macOS)
+- `~/Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md` — VS Code Insiders (macOS)
+- `~/.config/Code/User/prompts/copilot-defaults.instructions.md` — VS Code (Linux/XDG)
+- `~/.vscode-server/data/User/prompts/copilot-defaults.instructions.md` — VS Code Server
+
+Each symlink resolves through the current home-manager generation bundle in the
+nix store. To find the active nix store path for a given agent:
+
+```sh
+readlink -f ~/.config/claude/CLAUDE.md          # Claude variant
+readlink -f ~/.config/github-copilot/copilot-defaults.instructions.md  # Copilot variant
+```
+
+The chezmoi path for this file (`chezmoi/dot_config/instructions/`) makes the
+credential and cache-directory locations documented above discoverable on hosts
+that have chezmoi but not the full nix config.

--- a/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
+++ b/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
@@ -33,7 +33,18 @@ applyTo: "**"
   - **Confluence**: token at `~/.config/confluence/token`, base URL at
     `~/.config/confluence/base-url` (same SOPS source)
   - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
-    `~/.cache/kion-aws-cache/`
+    `~/.cache/kion-aws-cache/`. Credentials in `~/.aws/credentials` and
+    `AWS_PROFILE` are frequently stale and produce `ExpiredTokenException`.
+    Prefer loading directly from the Kion cache:
+
+    ```sh
+    export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
+    export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
+    export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
+    ```
+
+    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
+    refresh via `kion s` if the cache is empty.
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`

--- a/chezmoi/dot_config/instructions/agent-defaults.md
+++ b/chezmoi/dot_config/instructions/agent-defaults.md
@@ -23,7 +23,17 @@
   Bash before reading. Do not decompress speculatively; only decompress when
   uncompressed logs contain no useful example.
 - When looking for tool credentials, auth state, or cached session data, examine
-  ~/.cache first and then ~/.config.
+  ~/.cache first and then ~/.config. Known locations by service:
+  - **Jira**: token at `~/.config/ops-agent/jira-token`, base URL at
+    `~/.config/ops-agent/jira-base-url` (SOPS-decrypted from
+    `secrets/ops-agent.yaml` in the nix-config repo)
+  - **Confluence**: token at `~/.config/confluence/token`, base URL at
+    `~/.config/confluence/base-url` (same SOPS source)
+  - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
+    `~/.cache/kion-aws-cache/`
+  - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
+  - **SOPS age key** (decrypts all nix-managed secrets):
+    `~/.config/sops/age/keys.txt`
 - For Jira and Confluence operations, prefer direct REST/API-spec requests with
   configured tokens over dedicated `jira-cli` or `confluence-cli` wrappers.
 - For GitHub repository, issue, release, and pull request operations, prefer
@@ -63,3 +73,39 @@
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Agent Instruction Sources
+
+This file (`chezmoi/dot_config/instructions/agent-defaults.md`) is the single
+source of truth for persistent agent defaults. It is rendered by
+`home-manager/lib/agent-instructions.nix` (substituting `@@AGENT@@` with the
+agent name) and deployed as read-only symlinks via home-manager. Each deployed
+file is loaded into the agent session's system prompt at startup and is the
+primary source of Anthropic prompt-cache hits for that session.
+
+Stable deployment paths — these symlinks always point to the active generation:
+
+**Claude** (loaded via `CLAUDE_CONFIG_DIR` or fallback):
+
+- `~/.config/claude/CLAUDE.md` — primary
+- `~/.claude/CLAUDE.md` — fallback / memory resolution path
+
+**Copilot:**
+
+- `~/.config/github-copilot/copilot-defaults.instructions.md` — Copilot CLI
+- `~/Library/Application Support/Code/User/prompts/copilot-defaults.instructions.md` — VS Code stable (macOS)
+- `~/Library/Application Support/Code - Insiders/User/prompts/copilot-defaults.instructions.md` — VS Code Insiders (macOS)
+- `~/.config/Code/User/prompts/copilot-defaults.instructions.md` — VS Code (Linux/XDG)
+- `~/.vscode-server/data/User/prompts/copilot-defaults.instructions.md` — VS Code Server
+
+Each symlink resolves through the current home-manager generation bundle in the
+nix store. To find the active nix store path for a given agent:
+
+```sh
+readlink -f ~/.config/claude/CLAUDE.md          # Claude variant
+readlink -f ~/.config/github-copilot/copilot-defaults.instructions.md  # Copilot variant
+```
+
+The chezmoi path for this file (`chezmoi/dot_config/instructions/`) makes the
+credential and cache-directory locations documented above discoverable on hosts
+that have chezmoi but not the full nix config.

--- a/chezmoi/dot_config/instructions/agent-defaults.md
+++ b/chezmoi/dot_config/instructions/agent-defaults.md
@@ -30,7 +30,18 @@
   - **Confluence**: token at `~/.config/confluence/token`, base URL at
     `~/.config/confluence/base-url` (same SOPS source)
   - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
-    `~/.cache/kion-aws-cache/`
+    `~/.cache/kion-aws-cache/`. Credentials in `~/.aws/credentials` and
+    `AWS_PROFILE` are frequently stale and produce `ExpiredTokenException`.
+    Prefer loading directly from the Kion cache:
+
+    ```sh
+    export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
+    export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
+    export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
+    ```
+
+    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
+    refresh via `kion s` if the cache is empty.
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`

--- a/chezmoi/dot_local/bin/aws-mcp-server
+++ b/chezmoi/dot_local/bin/aws-mcp-server
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Wrapper for awslabs.aws-api-mcp-server that injects fresh AWS credentials
+# from the Kion cache before starting the server.
+set -euo pipefail
+
+kion="${HOME}/.cache/kion-aws-cache"
+
+if [[ -f "${kion}/AWS_ACCESS_KEY_ID" ]]; then
+	export AWS_ACCESS_KEY_ID=$(/bin/cat "${kion}/AWS_ACCESS_KEY_ID")
+	export AWS_SECRET_ACCESS_KEY=$(/bin/cat "${kion}/AWS_SECRET_ACCESS_KEY")
+	export AWS_SESSION_TOKEN=$(/bin/cat "${kion}/AWS_SESSION_TOKEN")
+fi
+
+exec uvx awslabs.aws-api-mcp-server@latest "$@"

--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778401693,
-        "narHash": "sha256-OVHdCqXXUF5UdGkH+FF2ZL06OLZjj2kvP2dIUmzVWoo=",
+        "lastModified": 1778905220,
+        "narHash": "sha256-ox/5IHc8uwy6UTw6N7Shp6uCHIgu/S2PsWeuXsOHSo8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "389b83002efc26f1145e89a6a8e6edc5a6435948",
+        "rev": "d1686dc7d36cbd1234cb226ad6ef97e882716acb",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778430510,
-        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
         "type": "github"
       },
       "original": {
@@ -336,11 +336,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1778105055,
-        "narHash": "sha256-SWz0cVHEGFb2rSszCaQ7nmuM9q7Cq3xbsg+DAg0N9jo=",
+        "lastModified": 1778680496,
+        "narHash": "sha256-tUq1WASV0dHLv3j18log8V6Esq0NYkXuzNH2EHsstcg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "68b1ff44196f4f593d0cd837ffb2a088c2870055",
+        "rev": "fc5bec2e44678eeaa221d566d447a0257a884737",
         "type": "github"
       },
       "original": {

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -95,6 +95,7 @@
     # Python
     python3
     pipx
+    uv
 
     # JavaScript
     bun
@@ -432,6 +433,20 @@ in {
           jq --arg local "$_local_path" \
             '.extraKnownMarketplaces["nix-config-dev"] = {source: {source: "directory", path: $local}}
              | .enabledPlugins["nix-config-tools@nix-config-dev"] = true' \
+            "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
+        fi
+      '';
+
+      ensureClaudeMcpServers = lib.hm.dag.entryAfter ["ensureClaudeHook"] ''
+        _settings="${xdgConfigHome}/claude/settings.json"
+        if ! ${pkgs.jq}/bin/jq -e '.mcpServers["awslabs.aws-api-mcp-server"]' "$_settings" > /dev/null 2>&1; then
+          _tmp=$(${pkgs.coreutils}/bin/mktemp)
+          ${pkgs.jq}/bin/jq \
+            '.mcpServers["awslabs.aws-api-mcp-server"] = {
+              "command": "uvx",
+              "args": ["awslabs.aws-api-mcp-server@latest"],
+              "env": {}
+            }' \
             "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
         fi
       '';

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -239,6 +239,17 @@ in {
         force = true;
       };
       "claude/log-bash.sh".source = ./local/bin/log-bash.sh;
+      "copilot/log-bash.sh".source = ./local/bin/log-bash.sh;
+      "copilot/hooks/log-bash.json".text = builtins.toJSON {
+        version = 1;
+        hooks.postToolUse = [
+          {
+            type = "command";
+            bash = ''AGENT_NAME=copilot exec bash "$HOME/.config/copilot/log-bash.sh"'';
+            timeoutSec = 10;
+          }
+        ];
+      };
 
       # Single source of truth for custom agent/skill definitions is the
       # top-level ai-tools/ directory (modeled on the obra/superpowers layout).

--- a/home-manager/home-darwin.nix
+++ b/home-manager/home-darwin.nix
@@ -153,7 +153,7 @@ in {
           "$HOME/Library/Application Support/Code - Insiders/User/prompts/agents"; do
           [ -d "$_dir" ] || continue
           for _f in "$_dir"/*.instructions.md; do
-            [ -f "$_f" ] || [ -L "$_f" ] || continue
+            [ -f "$_f" ] && [ ! -L "$_f" ] || continue
             ${pkgs.coreutils}/bin/rm -f "$_f"
           done
         done

--- a/home-manager/lib/code-editor-user-settings.nix
+++ b/home-manager/lib/code-editor-user-settings.nix
@@ -23,6 +23,12 @@
   "editor.inlayHints.fontFamily" = "FiraCode Nerd Font Mono";
   "editor.inlineSuggest.fontFamily" = "FiraCode Nerd Font Mono";
   "editor.minimap.sectionHeaderFontSize" = 10.285714285714286;
+  "[typescript]" = {
+    "editor.formatOnSave" = false;
+  };
+  "[typescriptreact]" = {
+    "editor.formatOnSave" = false;
+  };
   "[nix]" = {
     "editor.defaultFormatter" = "jnoortheen.nix-ide";
   };

--- a/home-manager/local/bin/log-bash.sh
+++ b/home-manager/local/bin/log-bash.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 input=$(cat)
 
 # Detect format by presence of Copilot's camelCase "toolName" vs Claude Code's "tool_input".
-if printf '%s' "$input" | jq -e '.toolName' > /dev/null 2>&1; then
+if printf '%s' "$input" | jq -e '.toolName' >/dev/null 2>&1; then
 	# Copilot postToolUse format: toolArgs is a JSON string, result nested under toolResult.
 	tool_name=$(printf '%s' "$input" | jq -r '.toolName // ""')
 	[[ "$tool_name" == "bash" ]] || exit 0

--- a/home-manager/local/bin/log-bash.sh
+++ b/home-manager/local/bin/log-bash.sh
@@ -2,19 +2,29 @@
 set -euo pipefail
 
 input=$(cat)
-cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
-sid=$(printf '%s' "$input" | jq -r '.session_id // "nosid"')
-resp=$(printf '%s' "$input" | jq -r '
-  if .tool_response == null then ""
-  elif (.tool_response | type) == "string" then .tool_response
-  else .tool_response | tostring
-  end')
+
+# Detect format by presence of Copilot's camelCase "toolName" vs Claude Code's "tool_input".
+if printf '%s' "$input" | jq -e '.toolName' > /dev/null 2>&1; then
+	# Copilot postToolUse format: toolArgs is a JSON string, result nested under toolResult.
+	tool_name=$(printf '%s' "$input" | jq -r '.toolName // ""')
+	[[ "$tool_name" == "bash" ]] || exit 0
+	cmd=$(printf '%s' "$input" | jq -r '(.toolArgs | fromjson | .command) // ""' 2>/dev/null || echo "")
+	sid=$(printf '%s' "$input" | jq -r '.sessionId // "nosid"')
+	resp=$(printf '%s' "$input" | jq -r '.toolResult.textResultForLlm // ""')
+else
+	# Claude Code PostToolUse format: tool_input is an object, tool_response is a string.
+	cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+	sid=$(printf '%s' "$input" | jq -r '.session_id // "nosid"')
+	resp=$(printf '%s' "$input" | jq -r '
+    if .tool_response == null then ""
+    elif (.tool_response | type) == "string" then .tool_response
+    else .tool_response | tostring
+    end')
+fi
 
 agent_raw="${AGENT_NAME:-claude}"
 agent=$(printf '%s' "$agent_raw" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9._-')
-if [[ -z "$agent" ]]; then
-	agent="claude"
-fi
+[[ -n "$agent" ]] || agent="claude"
 
 log_dir="$HOME/.cache/$agent"
 logfile="$log_dir/session_${sid}.log"


### PR DESCRIPTION
## Summary

- Extends `log-bash.sh` to handle both Claude Code (snake_case `tool_input`/`tool_response`) and Copilot (camelCase `toolName`/`toolArgs`/`toolResult`) hook JSON formats; filters to `toolName == "bash"` for Copilot
- Deploys `log-bash.sh` to `~/.config/copilot/` and generates `~/.config/copilot/hooks/log-bash.json` wiring the `postToolUse` hook with `AGENT_NAME=copilot`
- Fixes `cleanupStaleInstructionBridgesDarwin` to skip symlinks — previously the hook deleted old-generation `.instructions.md` symlinks before `cleanFiles` could handle them, causing repeated "does not link into a Home Manager generation" noise on every switch
- Injects `attribution: {commit: "", pr: ""}` into `~/.config/claude/settings.json` via the `ensureClaudeHook` activation to suppress co-author trailers globally

## Test plan

- [ ] `task switch` completes without "does not link into a Home Manager generation" messages for skills paths
- [ ] `~/.config/copilot/hooks/log-bash.json` present after switch
- [ ] Bash commands in a Copilot session appear in `~/.cache/copilot/session_*.log`
- [ ] Claude Code commits no longer include `Co-Authored-By` trailer

🤖 Generated with [Claude Code](https://claude.com/claude-code)