### PR TITLE
feat: track helper scripts in chezmoi and encrypt Go tool configs with SOPS

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,6 +10,10 @@ if ! command -v nix >/dev/null 2>&1; then
 fi
 
 printf '%s\n' 'pre-commit: running task lint:nix in a nix shell to match CI'
+# Unset TMPDIR so inner nix shells don't inherit a stale temp path from the
+# outer nix environment (e.g. when running inside Claude Code or another
+# nix-managed shell).
+unset TMPDIR
 nix shell nixpkgs#go-task nixpkgs#statix nixpkgs#deadnix -c task lint:nix
 
 printf '%s\n' 'pre-commit: scanning staged changes for secrets with gitleaks'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,18 +4,18 @@
 - If a shared shell shows prompt fragments, reused partial commands, or quote mangling,
   stop reusing it and rerun the workflow from an isolated shell.
 - When running terminal commands, also write the exact command and the resulting
-  output to files under `~/.cache/copilot`.
-- Ensure `~/.cache/copilot` exists once per session before attempting to write
+  output to files under ~/.cache/copilot.
+- Ensure ~/.cache/copilot exists once per session before attempting to write
   logs there.
 - For helper scripts or long text payloads, write temporary Go, Python, shell, or
-  data files to `~/.cache/copilot`. Prefer this over inline heredocs or long
+  data files to ~/.cache/copilot. Prefer this over inline heredocs or long
   inline command strings.
 - Prefer file-editing tools for long text whenever possible; reserve shell text
   construction for short, stable snippets.
 - Use append-safe logging or timestamped files so earlier command logs are not
   lost unless replacement is explicitly intended.
 - When investigating tool or command failures, inspect relevant logs under
-  `~/.cache/copilot` first; use prior successful executions there as concrete
+  ~/.cache/copilot first; use prior successful executions there as concrete
   examples before retrying or changing approach. Cache files are archived as
   `.zst` (Zstandard) by a Stop hook when older than 30 days or larger than 10
   MB. Search uncompressed files first. If no useful example is found, locate the
@@ -23,7 +23,7 @@
   Bash before reading. Do not decompress speculatively; only decompress when
   uncompressed logs contain no useful example.
 - When looking for tool credentials, auth state, or cached session data, examine
-  `~/.cache` first and then `~/.config`. Known locations by service:
+  ~/.cache first and then ~/.config. Known locations by service:
   - **Jira**: token at `~/.config/ops-agent/jira-token`, base URL at
     `~/.config/ops-agent/jira-base-url` (SOPS-decrypted from
     `secrets/ops-agent.yaml` in the nix-config repo)
@@ -40,8 +40,13 @@
     export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
     ```
 
-    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
-    refresh via `kion s` if the cache is empty.
+    Or source `~/.local/bin/kac ensure` (zsh only, must be sourced) to load
+    from cache or refresh automatically via `gkion` if the cache is stale:
+
+    ```sh
+    source ~/.local/bin/kac ensure
+    ```
+
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`
@@ -56,7 +61,7 @@
 
 ## Shared Tooling Defaults
 
-- The shared package set in `home-manager/common.nix` usually provides these CLI
+- The shared package set in home-manager/common.nix usually provides these CLI
   tools on managed hosts: git, gh, curl, wget, gcc, go, gopls, govulncheck,
   delve (`dlv`), go-task (`task`), pkg-config, python3, pipx, maven, awscli2,
   awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose,
@@ -71,7 +76,7 @@
   formatting and linting.
 - Treat this tool list as the default expected environment for repo work, but
   verify availability with `command -v` when portability matters because
-  `home-manager/common.nix` still filters packages by host support.
+  home-manager/common.nix still filters packages by host support.
 - Shell aliases `ls` to `eza`; use `/bin/ls` when exact BSD `ls` flags or output
   ordering matter.
 - In zsh wrappers, avoid `status` as a shell variable name; it is read-only. Use
@@ -82,8 +87,42 @@
   command, retry with a direct `/bin/zsh -f <script>` invocation before assuming
   file permissions are the issue.
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
-  objects, prefer writing a short script file under `~/.cache/copilot` and
+  objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Helper scripts in `~/.local/bin`
+
+These utility scripts are deployed to `~/.local/bin` (on `$PATH`) by chezmoi.
+Source files live in `chezmoi/dot_local/bin/` (and `chezmoi/dot_local/lib/`)
+within the nix-config repo. Prefer these over ad-hoc shell one-liners when
+they fit the task.
+
+- **`kac`** — Kion AWS credential cache proxy. Must be **sourced** (not
+  executed). Backed by `~/.local/lib/kion-aws-cache`. Commands:
+  - `source ~/.local/bin/kac ensure` — **(preferred)** load valid creds into
+    the current shell, refreshing automatically via `gkion` if the cache is
+    empty or expired. `gkion` writes the fresh creds back to
+    `~/.cache/kion-aws-cache/` as a side-effect.
+  - `source ~/.local/bin/kac dump` — write current valid AWS env vars to
+    `~/.cache/kion-aws-cache/`
+  - `source ~/.local/bin/kac load` — restore vars from cache into current
+    shell
+  - `source ~/.local/bin/kac clear` — unset vars and remove cache files
+  - `source ~/.local/bin/kac status` — print whether current/cached creds
+    are valid
+- **`monitor-gh-run <run-id>`** — Poll a GitHub Actions run, printing
+  per-job status transitions. Cancels older duplicate runs; switches to newer
+  runs automatically. Exits 0 on success, 1 on failure. Deps: `gh`, `jq`.
+- **`jira-my-tickets`** — Print open Jira tickets assigned to the current
+  user (status not Done, ordered by rank). Reads token from
+  `~/.config/ops-agent/jira-token` and email from
+  `~/.config/ops-agent/jira-email` (falls back to `git config user.email`).
+- **`compress-old-cache`** — Compress `~/.cache/copilot/` files older than
+  30 days with zstd. Invoked automatically by the copilot Stop hook.
+- **`toggle-browser`** — Toggle macOS default browser between Vivaldi and
+  Safari (darwin only).
+- **`ops-agent`** / **`cache-scan`** — Deployed via `home-manager/common.nix`
+  as `writeShellScriptBin`; source in `home-manager/local/bin/`.
 
 ## Agent Instruction Sources
 

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -20,13 +20,13 @@ keys:
 
 creation_rules:
   # Repository-level secrets shared across all hosts
-  - path_regex: secrets/.*\.(yaml|json|env|ini)$
+  - path_regex: secrets/.*\.(yaml|json|env|ini|toml)$
     key_groups:
       - age:
           - *user_jhettenh
 
   # Per-host secrets under hosts/<name>/secrets/
-  - path_regex: hosts/[^/]+/secrets/.*\.(yaml|json|env|ini)$
+  - path_regex: hosts/[^/]+/secrets/.*\.(yaml|json|env|ini|toml)$
     key_groups:
       - age:
           - *user_jhettenh

--- a/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
@@ -43,8 +43,13 @@ applyTo: "**"
     export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
     ```
 
-    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
-    refresh via `kion s` if the cache is empty.
+    Or source `~/.local/bin/kac ensure` (zsh only, must be sourced) to load
+    from cache or refresh automatically via `gkion` if the cache is stale:
+
+    ```sh
+    source ~/.local/bin/kac ensure
+    ```
+
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`
@@ -87,6 +92,40 @@ applyTo: "**"
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Helper scripts in `~/.local/bin`
+
+These utility scripts are deployed to `~/.local/bin` (on `$PATH`) by chezmoi.
+Source files live in `chezmoi/dot_local/bin/` (and `chezmoi/dot_local/lib/`)
+within the nix-config repo. Prefer these over ad-hoc shell one-liners when
+they fit the task.
+
+- **`kac`** — Kion AWS credential cache proxy. Must be **sourced** (not
+  executed). Backed by `~/.local/lib/kion-aws-cache`. Commands:
+  - `source ~/.local/bin/kac ensure` — **(preferred)** load valid creds into
+    the current shell, refreshing automatically via `gkion` if the cache is
+    empty or expired. `gkion` writes the fresh creds back to
+    `~/.cache/kion-aws-cache/` as a side-effect.
+  - `source ~/.local/bin/kac dump` — write current valid AWS env vars to
+    `~/.cache/kion-aws-cache/`
+  - `source ~/.local/bin/kac load` — restore vars from cache into current
+    shell
+  - `source ~/.local/bin/kac clear` — unset vars and remove cache files
+  - `source ~/.local/bin/kac status` — print whether current/cached creds
+    are valid
+- **`monitor-gh-run <run-id>`** — Poll a GitHub Actions run, printing
+  per-job status transitions. Cancels older duplicate runs; switches to newer
+  runs automatically. Exits 0 on success, 1 on failure. Deps: `gh`, `jq`.
+- **`jira-my-tickets`** — Print open Jira tickets assigned to the current
+  user (status not Done, ordered by rank). Reads token from
+  `~/.config/ops-agent/jira-token` and email from
+  `~/.config/ops-agent/jira-email` (falls back to `git config user.email`).
+- **`compress-old-cache`** — Compress `~/.cache/copilot/` files older than
+  30 days with zstd. Invoked automatically by the copilot Stop hook.
+- **`toggle-browser`** — Toggle macOS default browser between Vivaldi and
+  Safari (darwin only).
+- **`ops-agent`** / **`cache-scan`** — Deployed via `home-manager/common.nix`
+  as `writeShellScriptBin`; source in `home-manager/local/bin/`.
 
 ## Agent Instruction Sources
 

--- a/chezmoi/dot_config/claude/CLAUDE.md
+++ b/chezmoi/dot_config/claude/CLAUDE.md
@@ -40,8 +40,13 @@
     export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
     ```
 
-    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
-    refresh via `kion s` if the cache is empty.
+    Or source `~/.local/bin/kac ensure` (zsh only, must be sourced) to load
+    from cache or refresh automatically via `gkion` if the cache is stale:
+
+    ```sh
+    source ~/.local/bin/kac ensure
+    ```
+
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`
@@ -84,6 +89,40 @@
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Helper scripts in `~/.local/bin`
+
+These utility scripts are deployed to `~/.local/bin` (on `$PATH`) by chezmoi.
+Source files live in `chezmoi/dot_local/bin/` (and `chezmoi/dot_local/lib/`)
+within the nix-config repo. Prefer these over ad-hoc shell one-liners when
+they fit the task.
+
+- **`kac`** — Kion AWS credential cache proxy. Must be **sourced** (not
+  executed). Backed by `~/.local/lib/kion-aws-cache`. Commands:
+  - `source ~/.local/bin/kac ensure` — **(preferred)** load valid creds into
+    the current shell, refreshing automatically via `gkion` if the cache is
+    empty or expired. `gkion` writes the fresh creds back to
+    `~/.cache/kion-aws-cache/` as a side-effect.
+  - `source ~/.local/bin/kac dump` — write current valid AWS env vars to
+    `~/.cache/kion-aws-cache/`
+  - `source ~/.local/bin/kac load` — restore vars from cache into current
+    shell
+  - `source ~/.local/bin/kac clear` — unset vars and remove cache files
+  - `source ~/.local/bin/kac status` — print whether current/cached creds
+    are valid
+- **`monitor-gh-run <run-id>`** — Poll a GitHub Actions run, printing
+  per-job status transitions. Cancels older duplicate runs; switches to newer
+  runs automatically. Exits 0 on success, 1 on failure. Deps: `gh`, `jq`.
+- **`jira-my-tickets`** — Print open Jira tickets assigned to the current
+  user (status not Done, ordered by rank). Reads token from
+  `~/.config/ops-agent/jira-token` and email from
+  `~/.config/ops-agent/jira-email` (falls back to `git config user.email`).
+- **`compress-old-cache`** — Compress `~/.cache/claude/` files older than
+  30 days with zstd. Invoked automatically by the claude Stop hook.
+- **`toggle-browser`** — Toggle macOS default browser between Vivaldi and
+  Safari (darwin only).
+- **`ops-agent`** / **`cache-scan`** — Deployed via `home-manager/common.nix`
+  as `writeShellScriptBin`; source in `home-manager/local/bin/`.
 
 ## Agent Instruction Sources
 

--- a/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
@@ -43,8 +43,13 @@ applyTo: "**"
     export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
     ```
 
-    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
-    refresh via `kion s` if the cache is empty.
+    Or source `~/.local/bin/kac ensure` (zsh only, must be sourced) to load
+    from cache or refresh automatically via `gkion` if the cache is stale:
+
+    ```sh
+    source ~/.local/bin/kac ensure
+    ```
+
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`
@@ -87,6 +92,40 @@ applyTo: "**"
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Helper scripts in `~/.local/bin`
+
+These utility scripts are deployed to `~/.local/bin` (on `$PATH`) by chezmoi.
+Source files live in `chezmoi/dot_local/bin/` (and `chezmoi/dot_local/lib/`)
+within the nix-config repo. Prefer these over ad-hoc shell one-liners when
+they fit the task.
+
+- **`kac`** — Kion AWS credential cache proxy. Must be **sourced** (not
+  executed). Backed by `~/.local/lib/kion-aws-cache`. Commands:
+  - `source ~/.local/bin/kac ensure` — **(preferred)** load valid creds into
+    the current shell, refreshing automatically via `gkion` if the cache is
+    empty or expired. `gkion` writes the fresh creds back to
+    `~/.cache/kion-aws-cache/` as a side-effect.
+  - `source ~/.local/bin/kac dump` — write current valid AWS env vars to
+    `~/.cache/kion-aws-cache/`
+  - `source ~/.local/bin/kac load` — restore vars from cache into current
+    shell
+  - `source ~/.local/bin/kac clear` — unset vars and remove cache files
+  - `source ~/.local/bin/kac status` — print whether current/cached creds
+    are valid
+- **`monitor-gh-run <run-id>`** — Poll a GitHub Actions run, printing
+  per-job status transitions. Cancels older duplicate runs; switches to newer
+  runs automatically. Exits 0 on success, 1 on failure. Deps: `gh`, `jq`.
+- **`jira-my-tickets`** — Print open Jira tickets assigned to the current
+  user (status not Done, ordered by rank). Reads token from
+  `~/.config/ops-agent/jira-token` and email from
+  `~/.config/ops-agent/jira-email` (falls back to `git config user.email`).
+- **`compress-old-cache`** — Compress `~/.cache/copilot/` files older than
+  30 days with zstd. Invoked automatically by the copilot Stop hook.
+- **`toggle-browser`** — Toggle macOS default browser between Vivaldi and
+  Safari (darwin only).
+- **`ops-agent`** / **`cache-scan`** — Deployed via `home-manager/common.nix`
+  as `writeShellScriptBin`; source in `home-manager/local/bin/`.
 
 ## Agent Instruction Sources
 

--- a/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
+++ b/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
@@ -43,8 +43,13 @@ applyTo: "**"
     export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
     ```
 
-    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
-    refresh via `kion s` if the cache is empty.
+    Or source `~/.local/bin/kac ensure` (zsh only, must be sourced) to load
+    from cache or refresh automatically via `gkion` if the cache is stale:
+
+    ```sh
+    source ~/.local/bin/kac ensure
+    ```
+
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`
@@ -87,6 +92,40 @@ applyTo: "**"
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Helper scripts in `~/.local/bin`
+
+These utility scripts are deployed to `~/.local/bin` (on `$PATH`) by chezmoi.
+Source files live in `chezmoi/dot_local/bin/` (and `chezmoi/dot_local/lib/`)
+within the nix-config repo. Prefer these over ad-hoc shell one-liners when
+they fit the task.
+
+- **`kac`** — Kion AWS credential cache proxy. Must be **sourced** (not
+  executed). Backed by `~/.local/lib/kion-aws-cache`. Commands:
+  - `source ~/.local/bin/kac ensure` — **(preferred)** load valid creds into
+    the current shell, refreshing automatically via `gkion` if the cache is
+    empty or expired. `gkion` writes the fresh creds back to
+    `~/.cache/kion-aws-cache/` as a side-effect.
+  - `source ~/.local/bin/kac dump` — write current valid AWS env vars to
+    `~/.cache/kion-aws-cache/`
+  - `source ~/.local/bin/kac load` — restore vars from cache into current
+    shell
+  - `source ~/.local/bin/kac clear` — unset vars and remove cache files
+  - `source ~/.local/bin/kac status` — print whether current/cached creds
+    are valid
+- **`monitor-gh-run <run-id>`** — Poll a GitHub Actions run, printing
+  per-job status transitions. Cancels older duplicate runs; switches to newer
+  runs automatically. Exits 0 on success, 1 on failure. Deps: `gh`, `jq`.
+- **`jira-my-tickets`** — Print open Jira tickets assigned to the current
+  user (status not Done, ordered by rank). Reads token from
+  `~/.config/ops-agent/jira-token` and email from
+  `~/.config/ops-agent/jira-email` (falls back to `git config user.email`).
+- **`compress-old-cache`** — Compress `~/.cache/copilot/` files older than
+  30 days with zstd. Invoked automatically by the copilot Stop hook.
+- **`toggle-browser`** — Toggle macOS default browser between Vivaldi and
+  Safari (darwin only).
+- **`ops-agent`** / **`cache-scan`** — Deployed via `home-manager/common.nix`
+  as `writeShellScriptBin`; source in `home-manager/local/bin/`.
 
 ## Agent Instruction Sources
 

--- a/chezmoi/dot_config/instructions/agent-defaults.md
+++ b/chezmoi/dot_config/instructions/agent-defaults.md
@@ -40,8 +40,13 @@
     export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
     ```
 
-    Or run `source ~/.local/bin/kac ensure` (zsh only, must be sourced) to
-    refresh via `kion s` if the cache is empty.
+    Or source `~/.local/bin/kac ensure` (zsh only, must be sourced) to load
+    from cache or refresh automatically via `gkion` if the cache is stale:
+
+    ```sh
+    source ~/.local/bin/kac ensure
+    ```
+
   - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
   - **SOPS age key** (decrypts all nix-managed secrets):
     `~/.config/sops/age/keys.txt`
@@ -84,6 +89,40 @@
 - For shell commands with JSON payloads, inline scripts, or heavily quoted
   objects, prefer writing a short script file under ~/.cache/copilot and
   executing that file instead of retrying inline `zsh -c` command strings.
+
+## Helper scripts in `~/.local/bin`
+
+These utility scripts are deployed to `~/.local/bin` (on `$PATH`) by chezmoi.
+Source files live in `chezmoi/dot_local/bin/` (and `chezmoi/dot_local/lib/`)
+within the nix-config repo. Prefer these over ad-hoc shell one-liners when
+they fit the task.
+
+- **`kac`** — Kion AWS credential cache proxy. Must be **sourced** (not
+  executed). Backed by `~/.local/lib/kion-aws-cache`. Commands:
+  - `source ~/.local/bin/kac ensure` — **(preferred)** load valid creds into
+    the current shell, refreshing automatically via `gkion` if the cache is
+    empty or expired. `gkion` writes the fresh creds back to
+    `~/.cache/kion-aws-cache/` as a side-effect.
+  - `source ~/.local/bin/kac dump` — write current valid AWS env vars to
+    `~/.cache/kion-aws-cache/`
+  - `source ~/.local/bin/kac load` — restore vars from cache into current
+    shell
+  - `source ~/.local/bin/kac clear` — unset vars and remove cache files
+  - `source ~/.local/bin/kac status` — print whether current/cached creds
+    are valid
+- **`monitor-gh-run <run-id>`** — Poll a GitHub Actions run, printing
+  per-job status transitions. Cancels older duplicate runs; switches to newer
+  runs automatically. Exits 0 on success, 1 on failure. Deps: `gh`, `jq`.
+- **`jira-my-tickets`** — Print open Jira tickets assigned to the current
+  user (status not Done, ordered by rank). Reads token from
+  `~/.config/ops-agent/jira-token` and email from
+  `~/.config/ops-agent/jira-email` (falls back to `git config user.email`).
+- **`compress-old-cache`** — Compress `~/.cache/@@AGENT@@/` files older than
+  30 days with zstd. Invoked automatically by the @@AGENT@@ Stop hook.
+- **`toggle-browser`** — Toggle macOS default browser between Vivaldi and
+  Safari (darwin only).
+- **`ops-agent`** / **`cache-scan`** — Deployed via `home-manager/common.nix`
+  as `writeShellScriptBin`; source in `home-manager/local/bin/`.
 
 ## Agent Instruction Sources
 

--- a/chezmoi/dot_local/bin/jira-my-tickets
+++ b/chezmoi/dot_local/bin/jira-my-tickets
@@ -1,0 +1,29 @@
+#!/bin/zsh
+# List open Jira tickets assigned to the current user.
+# Reads credentials from ~/.config/ops-agent/{jira-token,jira-base-url}.
+# Email is read from ~/.config/ops-agent/jira-email; falls back to git config.
+set -euo pipefail
+
+JIRA_BASE_RAW=$(/bin/cat ~/.config/ops-agent/jira-base-url)
+JIRA_BASE="${JIRA_BASE_RAW%/rest/api/2}"
+JIRA_TOKEN=$(/bin/cat ~/.config/ops-agent/jira-token)
+
+if [[ -f ~/.config/ops-agent/jira-email ]]; then
+  JIRA_EMAIL=$(/bin/cat ~/.config/ops-agent/jira-email)
+else
+  JIRA_EMAIL=$(git config --global user.email 2>/dev/null) || {
+    echo "jira-my-tickets: cannot determine email — set ~/.config/ops-agent/jira-email" >&2
+    exit 1
+  }
+fi
+
+OUT=$(mktemp)
+trap 'rm -f "$OUT"' EXIT
+
+curl -s \
+  -u "$JIRA_EMAIL:$JIRA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -o "$OUT" \
+  "${JIRA_BASE}/rest/api/2/search?jql=assignee%3DcurrentUser()%20AND%20statusCategory%20!%3D%20Done%20ORDER%20BY%20rank%20ASC&fields=key,summary,status,priority,issuetype&maxResults=25"
+
+jq '.issues[] | {key: .key, summary: .fields.summary, status: .fields.status.name, priority: .fields.priority.name, type: .fields.issuetype.name}' "$OUT"

--- a/chezmoi/dot_local/bin/kac
+++ b/chezmoi/dot_local/bin/kac
@@ -1,0 +1,19 @@
+#!/bin/zsh
+# Source this proxy so it can mutate the current shell:
+#   source ~/.local/bin/kac [dump|load|clear|status]
+
+if ! (return 0 2>/dev/null); then
+  echo "This proxy must be sourced, not executed." >&2
+  echo "Use: source ~/.local/bin/kac [command]" >&2
+  exit 1
+fi
+
+_kac_script_path="${(%):-%N}"
+_kac_helper_path="${_kac_script_path:A:h:h}/lib/kion-aws-cache"
+
+if ! source "$_kac_helper_path" "$@"; then
+  unset _kac_script_path _kac_helper_path
+  return 1
+fi
+
+unset _kac_script_path _kac_helper_path

--- a/chezmoi/dot_local/bin/monitor-gh-run
+++ b/chezmoi/dot_local/bin/monitor-gh-run
@@ -1,0 +1,116 @@
+#!/bin/zsh
+# Usage: monitor-gh-run <run-id>
+# Polls a GH Actions run every 20s, prints per-job status changes,
+# exits 1 immediately on any job failure, exits 0 when all jobs succeed.
+#
+# Duplicate-run handling: on every poll the script checks for other active
+# (non-completed) runs of the same workflow on the same branch.
+#   - Any run with a LOWER ID (older) is cancelled immediately.
+#   - If a run with a HIGHER ID (newer) exists, the current run is cancelled
+#     and the script switches to monitor the newer one instead.
+set -euo pipefail
+
+RUN_ID="${1:?Usage: $0 <run-id>}"
+INTERVAL=20
+declare -A LAST_STATUS
+
+resolve_run_meta() {
+  local id="$1"
+  RUN_META=$(gh run view "$id" --json databaseId,headBranch,workflowName,name 2>/dev/null) || {
+    echo "❌ Could not fetch metadata for run $id" >&2; exit 1
+  }
+  BRANCH=$(echo "$RUN_META" | jq -r '.headBranch')
+  WORKFLOW=$(echo "$RUN_META" | jq -r '.workflowName')
+  RUN_NAME=$(echo "$RUN_META" | jq -r '.name')
+}
+
+resolve_run_meta "$RUN_ID"
+echo "Monitoring run $RUN_ID — $RUN_NAME (branch: $BRANCH)"
+
+while true; do
+  # Fetch all recent runs without a status filter, then keep non-completed
+  # ones in jq. This avoids the multi-query problem where "pending" runs
+  # are missed by --status queued / --status in_progress filters.
+  active_runs=$(gh run list \
+    --branch "$BRANCH" \
+    --workflow "$WORKFLOW" \
+    --limit 20 \
+    --json databaseId,status \
+    2>/dev/null \
+    | jq '[.[] | select(.status != "completed")] | sort_by(.databaseId)')
+    # sorted ascending: index 0 = oldest, last = newest
+
+  # Cancel any runs with ID lower than ours (older duplicates)
+  while IFS= read -r old_id; do
+    if (( old_id < RUN_ID )); then
+      ts=$(date '+%H:%M:%S')
+      echo "[$ts] 🗑  Cancelling older duplicate run $old_id"
+      gh run cancel "$old_id" 2>/dev/null || true
+    fi
+  done < <(echo "$active_runs" | jq -r '.[].databaseId | tostring')
+
+  # If a run with a higher ID exists, cancel ours and switch to it
+  newest_id=$(echo "$active_runs" | jq -r 'last.databaseId // empty')
+  if [[ -n "$newest_id" ]] && (( newest_id > RUN_ID )); then
+    ts=$(date '+%H:%M:%S')
+    echo "[$ts] 🔀 Newer run $newest_id found — cancelling $RUN_ID and switching"
+    gh run cancel "$RUN_ID" 2>/dev/null || true
+    RUN_ID="$newest_id"
+    resolve_run_meta "$RUN_ID"
+    echo "[$ts] Monitoring run $RUN_ID — $RUN_NAME"
+    LAST_STATUS=()
+  fi
+
+  snapshot=$(gh run view "$RUN_ID" --json status,conclusion,jobs 2>/dev/null) || { sleep "$INTERVAL"; continue; }
+
+  overall_status=$(echo "$snapshot" | jq -r '.status')
+  overall_conclusion=$(echo "$snapshot" | jq -r '.conclusion // ""')
+
+  # Print job transitions
+  while IFS='|' read -r jname jrc jconclusion; do
+    key="${jname// /_}"
+    current="${jrc}/${jconclusion}"
+    if [[ "${LAST_STATUS[$key]:-}" != "$current" ]]; then
+      LAST_STATUS[$key]="$current"
+      ts=$(date '+%H:%M:%S')
+      if [[ "$jconclusion" == "failure" ]]; then
+        echo "[$ts] ❌ FAILED:    $jname"
+      elif [[ "$jconclusion" == "success" ]]; then
+        echo "[$ts] ✅ passed:    $jname"
+      elif [[ "$jconclusion" == "skipped" ]]; then
+        echo "[$ts] ⏭  skipped:   $jname"
+      elif [[ "$jconclusion" == "cancelled" ]]; then
+        echo "[$ts] 🚫 cancelled: $jname"
+      elif [[ "$jrc" == "in_progress" ]]; then
+        echo "[$ts] 🔄 started:   $jname"
+      elif [[ "$jrc" == "queued" || "$jrc" == "pending" || "$jrc" == "waiting" ]]; then
+        echo "[$ts] ⏳ queued:    $jname"
+      fi
+    fi
+  done < <(echo "$snapshot" | jq -r '.jobs[] | "\(.name)|\(.status)|\(.conclusion // "")"')
+
+  # Exit immediately on any job failure
+  if echo "$snapshot" | jq -e '.jobs[] | select(.conclusion == "failure")' > /dev/null 2>&1; then
+    echo ""
+    echo "❌ Run $RUN_ID FAILED — failed jobs:"
+    echo "$snapshot" | jq -r '.jobs[] | select(.conclusion == "failure") | "  - \(.name)"'
+    echo "URL: $(gh run view "$RUN_ID" --json url --jq '.url' 2>/dev/null)"
+    exit 1
+  fi
+
+  if [[ "$overall_status" == "completed" ]]; then
+    if [[ "$overall_conclusion" == "success" ]]; then
+      echo ""
+      echo "✅ Run $RUN_ID completed successfully."
+      echo "URL: $(gh run view "$RUN_ID" --json url --jq '.url' 2>/dev/null)"
+      exit 0
+    else
+      echo ""
+      echo "❌ Run $RUN_ID completed: $overall_conclusion"
+      echo "URL: $(gh run view "$RUN_ID" --json url --jq '.url' 2>/dev/null)"
+      exit 1
+    fi
+  fi
+
+  sleep "$INTERVAL"
+done

--- a/chezmoi/dot_local/lib/kion-aws-cache
+++ b/chezmoi/dot_local/lib/kion-aws-cache
@@ -1,0 +1,205 @@
+#!/bin/zsh
+# Source this file from the current interactive shell:
+#   source ~/.local/lib/kion-aws-cache [dump|load|clear|status|ensure]
+
+_kion_aws_cache_main() {
+  setopt localoptions no_unset 2>/dev/null || true
+
+  local cache_root="$HOME/.cache/kion-aws-cache"
+  local -a vars=(AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN)
+  local command="${1:-help}"
+
+  _kion_aws_cache_usage() {
+    cat <<'EOF'
+Usage:
+  source ~/.local/lib/kion-aws-cache [command]
+
+Commands:
+  ensure  Load valid creds into current shell, refreshing via gkion if needed.
+  dump    Dump current AWS vars to cache files if they are still valid.
+  load    Load AWS vars from cache files into the current shell.
+  clear   Remove cached AWS vars and unset them from the current shell.
+  status  Print whether current and cached credentials appear valid.
+EOF
+  }
+
+  _kion_aws_cache_require_sourced() {
+    if ! (return 0 2>/dev/null); then
+      echo "This helper must be sourced, not executed." >&2
+      echo "Use: source ~/.local/lib/kion-aws-cache [command]" >&2
+      exit 1
+    fi
+  }
+
+  _kion_aws_cache_has_values() {
+    local name
+    for name in "${vars[@]}"; do
+      [[ -n "${(P)name:-}" ]] || return 1
+    done
+  }
+
+  _kion_aws_cache_cache_has_values() {
+    local name file
+    for name in "${vars[@]}"; do
+      file="$cache_root/$name"
+      [[ -s "$file" ]] || return 1
+    done
+  }
+
+  _kion_aws_cache_validate_values() {
+    local access_key_id="$1"
+    local secret_access_key="$2"
+    local session_token="$3"
+
+    [[ -n "$access_key_id" && -n "$secret_access_key" && -n "$session_token" ]] || return 1
+
+    AWS_ACCESS_KEY_ID="$access_key_id" \
+    AWS_SECRET_ACCESS_KEY="$secret_access_key" \
+    AWS_SESSION_TOKEN="$session_token" \
+      aws sts get-caller-identity >/dev/null 2>&1
+  }
+
+  _kion_aws_cache_validate_current() {
+    _kion_aws_cache_has_values || return 1
+    _kion_aws_cache_validate_values \
+      "${AWS_ACCESS_KEY_ID:-}" \
+      "${AWS_SECRET_ACCESS_KEY:-}" \
+      "${AWS_SESSION_TOKEN:-}"
+  }
+
+  _kion_aws_cache_mkdir() {
+    umask 077
+    mkdir -p "$cache_root"
+    chmod 700 "$cache_root" 2>/dev/null || true
+  }
+
+  _kion_aws_cache_dump() {
+    if ! _kion_aws_cache_validate_current; then
+      echo "AWS credentials are expired." >&2
+      return 1
+    fi
+
+    _kion_aws_cache_mkdir
+
+    local name file value
+    for name in "${vars[@]}"; do
+      file="$cache_root/$name"
+      value="${(P)name}"
+      printf '%s' "$value" > "$file"
+      chmod 600 "$file" 2>/dev/null || true
+    done
+  }
+
+  _kion_aws_cache_load() {
+    _kion_aws_cache_cache_has_values || {
+      echo "Cached AWS credentials were not found in $cache_root." >&2
+      return 1
+    }
+
+    local access_key_id secret_access_key session_token
+    access_key_id="$(<"$cache_root/AWS_ACCESS_KEY_ID")"
+    secret_access_key="$(<"$cache_root/AWS_SECRET_ACCESS_KEY")"
+    session_token="$(<"$cache_root/AWS_SESSION_TOKEN")"
+
+    if ! _kion_aws_cache_validate_values "$access_key_id" "$secret_access_key" "$session_token"; then
+      echo "AWS credentials are expired." >&2
+      return 1
+    fi
+
+    export AWS_ACCESS_KEY_ID="$access_key_id"
+    export AWS_SECRET_ACCESS_KEY="$secret_access_key"
+    export AWS_SESSION_TOKEN="$session_token"
+  }
+
+  _kion_aws_cache_clear() {
+    local name file
+    for name in "${vars[@]}"; do
+      unset "$name"
+      file="$cache_root/$name"
+      [[ -e "$file" ]] && rm -f "$file"
+    done
+  }
+
+  _kion_aws_cache_ensure() {
+    # 1. Current env creds are already valid — nothing to do.
+    if _kion_aws_cache_validate_current 2>/dev/null; then
+      return 0
+    fi
+
+    # 2. Cache files hold valid creds — load them.
+    if _kion_aws_cache_load 2>/dev/null; then
+      return 0
+    fi
+
+    # 3. Both stale — call gkion to obtain fresh credentials.
+    # gkion env prints "export VAR=value" lines AND writes the same values
+    # to ~/.cache/kion-aws-cache/ (cache.write_files=true in gkion config),
+    # so the cache is updated as a side-effect.
+    if ! command -v gkion >/dev/null 2>&1; then
+      echo "kac ensure: credentials expired and gkion is not installed" >&2
+      return 1
+    fi
+
+    local exports
+    exports=$(gkion env 2>/tmp/kac-ensure-err) || {
+      echo "kac ensure: gkion env failed" >&2
+      /bin/cat /tmp/kac-ensure-err >&2
+      return 1
+    }
+    eval "$exports"
+  }
+
+  _kion_aws_cache_status() {
+    local current_state cache_state
+    if _kion_aws_cache_validate_current; then
+      current_state="valid"
+    elif _kion_aws_cache_has_values; then
+      current_state="set-but-invalid"
+    else
+      current_state="missing"
+    fi
+
+    if _kion_aws_cache_cache_has_values; then
+      cache_state="present"
+    else
+      cache_state="missing"
+    fi
+
+    printf 'current=%s\ncache=%s\ncache_dir=%s\n' "$current_state" "$cache_state" "$cache_root"
+  }
+
+  _kion_aws_cache_require_sourced
+
+  case "$command" in
+    ensure)
+      _kion_aws_cache_ensure
+      ;;
+    dump)
+      _kion_aws_cache_dump
+      ;;
+    load)
+      _kion_aws_cache_load
+      ;;
+    clear)
+      _kion_aws_cache_clear
+      ;;
+    status)
+      _kion_aws_cache_status
+      ;;
+    help|-h|--help)
+      _kion_aws_cache_usage
+      ;;
+    *)
+      echo "Unknown command: $command" >&2
+      _kion_aws_cache_usage >&2
+      return 1
+      ;;
+  esac
+}
+
+if ! _kion_aws_cache_main "$@"; then
+  unfunction _kion_aws_cache_main 2>/dev/null || true
+  return 1
+fi
+
+unfunction _kion_aws_cache_main 2>/dev/null || true

--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778905220,
-        "narHash": "sha256-ox/5IHc8uwy6UTw6N7Shp6uCHIgu/S2PsWeuXsOHSo8=",
+        "lastModified": 1779506708,
+        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d1686dc7d36cbd1234cb226ad6ef97e882716acb",
+        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1779467186,
+        "narHash": "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "b77b3de8775677f84492abe84635f87b0e153f0f",
         "type": "github"
       },
       "original": {

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -117,6 +117,7 @@
     eza
     fzf
     fd
+    overmind
     ripgrep
     sd
     zoxide

--- a/home-manager/modules/sops.nix
+++ b/home-manager/modules/sops.nix
@@ -1,7 +1,12 @@
 # Home-manager sops-nix configuration
 # Decrypts user-level secrets at home-manager activation time using an age key.
 # Generate a key with: age-keygen -o ~/.config/sops/age/keys.txt
-{config, ...}: {
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
   sops = {
     age.keyFile = "${config.home.homeDirectory}/.config/sops/age/keys.txt";
     defaultSopsFormat = "yaml";
@@ -24,5 +29,33 @@
         path = "${config.home.homeDirectory}/.config/confluence/token";
       };
     };
+  };
+
+  # Whole-file TOML secrets: sops-nix extracts individual keys, but these tools
+  # expect a complete config.toml, so we decrypt the whole file via activation.
+  home.activation = {
+    decryptGkionConfig = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      _age_key="${config.home.homeDirectory}/.config/sops/age/keys.txt"
+      if [ -f "$_age_key" ]; then
+        ${pkgs.coreutils}/bin/mkdir -p "${config.home.homeDirectory}/.config/gkion"
+        SOPS_AGE_KEY_FILE="$_age_key" \
+          ${pkgs.sops}/bin/sops --decrypt \
+          ${../../secrets/gkion.toml} \
+          > "${config.home.homeDirectory}/.config/gkion/config.toml"
+        ${pkgs.coreutils}/bin/chmod 600 "${config.home.homeDirectory}/.config/gkion/config.toml"
+      fi
+    '';
+
+    decryptTechnitiumConfig = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      _age_key="${config.home.homeDirectory}/.config/sops/age/keys.txt"
+      if [ -f "$_age_key" ]; then
+        ${pkgs.coreutils}/bin/mkdir -p "${config.home.homeDirectory}/.config/technitiumdns-cli"
+        SOPS_AGE_KEY_FILE="$_age_key" \
+          ${pkgs.sops}/bin/sops --decrypt \
+          ${../../secrets/technitiumdns-cli.toml} \
+          > "${config.home.homeDirectory}/.config/technitiumdns-cli/config.toml"
+        ${pkgs.coreutils}/bin/chmod 600 "${config.home.homeDirectory}/.config/technitiumdns-cli/config.toml"
+      fi
+    '';
   };
 }

--- a/scripts/encrypt-secrets.sh
+++ b/scripts/encrypt-secrets.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Non-interactive variant of secret provisioning for ops-agent.yaml.
+# Reads tokens from their standard config locations and writes them into the
+# SOPS-encrypted secrets/ops-agent.yaml in this repo.
+#
+# Prerequisites: age key at ~/.config/sops/age/keys.txt, tokens already placed
+# at their expected paths (run provision-secrets.sh first if needed).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+YAML="$REPO_ROOT/secrets/ops-agent.yaml"
+export SOPS_AGE_KEY_FILE="${HOME}/.config/sops/age/keys.txt"
+
+jira_token=$(/bin/cat "${HOME}/.config/ops-agent/jira-token")
+confluence_token=$(/bin/cat "${HOME}/.config/confluence/token")
+confluence_url=$(/bin/cat "${HOME}/.config/confluence/base-url" 2>/dev/null || echo "")
+
+if [[ -z "$confluence_url" ]]; then
+  echo "encrypt-secrets: ~/.config/confluence/base-url not found" >&2
+  exit 1
+fi
+
+sops --set '["ops_agent"]["jira_token"] "'"$jira_token"'"' "$YAML"
+sops --set '["ops_agent"]["confluence_base_url"] "'"$confluence_url"'"' "$YAML"
+sops --set '["ops_agent"]["confluence_token"] "'"$confluence_token"'"' "$YAML"
+
+echo "Done. Keys written to $YAML:"
+sops -d "$YAML" | grep -E '^\s+\w+:' | awk '{print $1}'

--- a/secrets/gkion.toml
+++ b/secrets/gkion.toml
@@ -1,0 +1,14 @@
+{
+	"data": "ENC[AES256_GCM,data:HYIr2tOH11/QNfsHHkCWpBimJUfd3qmT4HWL79CHjS8lpqh/pHlLSe7C5r/6TJ3BjfrYYZMfzPu2JnDuQWu1QXUJ3R4qQqfqaicgwG4niRSCv2NB84gCTaRqMZdH6tnoIPOuP/SSoTcNG08zewlIjv+mZaFtYtOl7xmMOZNMJGdHtpjDqYzg+UntU+NVt3xY0+DUWK9pcQxtFMr6RiB9uC4JWn7UK64BiA7nDZWNIvRYmHPVqhBaXEgrTVXt7AEnCY4wlCrknnufT459EfHI7UqRFlWjCp3ouyynEBDKpOo2/Hr5aK2BO4+46hdmONuSVtBItE0jHjhIHA47M7NuIZ47sRW/iVL5JBgztsyvKLCIuQtB4NPdzhBLEu3Pv0jAWZgZ3bj27tVeRF1p+4oqHh1x1wJi/cMgrvg5v4jKnNtlqxBF/3cKJSCpKED/co88xUUbI8BJU+tPECuoDU6Jmf6uszLxCcIlhXWnO3xS7ki4WpITQ538jbbu6zSuneIq52ffkc0zNDbzfMxeizJTw7WEk8Z3xj8=,iv:QTXiOlDqb81g3js3wfwsVTPd5iTKO8DdVlva/zNj8FA=,tag:Cqza2amM8tHV6LA5YAkUYg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age19vlys87e2zs36pv4aq2m026qrxxk4e0wh44gxr3y98shrpnamvsqm7mgpk",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvMXRxb2RBUTF2UXJ6QjJo\nNzkxUTJGQkpUVTd5NGY1UWNJVTNCYzZRQlgwCjdmYmkrWnNLMUU3RGVJM0Y0VXd5\nTDFkcU9oQ1U3MCtBeDlrTUcwMUNoVEkKLS0tIFlxdkJBWlR3T0Y1ZmhmQXVOaGlG\nWWg2OVNOWGh6ekVvNFltdzRkVnZsMTAKYAUYb9i5r2M4MPBtDzf50WBzozD3GDUP\nHepmlLcUgeJLcvBYV6m5icHv1l47T4wvnRaEFUFfckUh4Fggtx4Jaw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-05-27T16:43:56Z",
+		"mac": "ENC[AES256_GCM,data:eNz4+UQrJYoVLe1GVfcZRYBZBjL0Lj3zTBLPjVwxw8BcAPKMN+1MX4V8soKGqo7oBIM2fxqzpXKxD0fNEtvbiNHZ7UPfbt+SnDiBMY3dAsM0DJk70NQv5MWFdlRxNjcu0SRxxk2Jj5aWVcLNvihPRsqeg68q0/5DNhldsfCWdy8=,iv:i/vVP3w73zW1OyNnhrB1vpvZuVRn2QnUgyk+5KF+DPk=,tag:S6dUrAyQlBl29+ymEr/g5Q==,type:str]",
+		"version": "3.12.1"
+	}
+}

--- a/secrets/technitiumdns-cli.toml
+++ b/secrets/technitiumdns-cli.toml
@@ -1,0 +1,14 @@
+{
+	"data": "ENC[AES256_GCM,data:FRjMS4ZQj4XYd6o1h5MSqHUwv8iDIjGgdIwjGxAd59fO7a8wxD63mG65Wqb+ppAq9DiJN4ibynU80eC1qVM4PaiR8Jgp6gflkZ4WQCaxMbgChmjmcvT9DYvHjgbqvQGVHoO4oBZZzYqxoicvOLBGbH9bmT3rQaP4OqKQUTBwI5jNpEV7pGhyF6o/6MtZUJ+jPBbGoIAUwPRcEPgYr3h/em6vc1eTy7iqfeIGatyIh+mM63LkW9CKW3fgIqiPKF60EkSQC0PxDtCpkOUifhsKnR9dxDjgdA/vOTTtRQQotHaRRlaVQRN0Jl/+AXWwMp2HNjVvae1TMVmvlHP3S395leD8kstFVGxMhdv433uvX4iM5a+qjy1ijSFwPMDH8d5c5hAQoG1jtj6alsVQvTCeWVtSA4NUygmTalget5E37+w/0uoKbk/1njY+r0OCKt+jzzk7b2YCQhIb2DoNl6wqi85RB8a0tetdETEImwOrENWLwh1DAEYHY55AaGQiddMX0GpC7Q3OAQ6NfjlPLZnGe5ODLvahD88maYDFw+3cN709YezsdKGT5QLA0IKYbNS5k1zu,iv:erDxbpf04DItq2eKomclxgQ5yQ7B/fqymtfEg5tQ1n4=,tag:ZHm/2XIKwdnKsICpJWX4+g==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age19vlys87e2zs36pv4aq2m026qrxxk4e0wh44gxr3y98shrpnamvsqm7mgpk",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjYllFTDJ1VWd1RGRDN2M3\nUVRQNjloaDdDU1o3N2l0cEdNbmpqZ3YrYW13CkpmYnFsV0tEa0NITkJra2MvYTdh\ndGlRZFF4bEJsb3YzcVQyMTZwa0dtOEkKLS0tICtpY0FPcDBESXpvZkpxQWJqVVdM\nMzF2cEszYllQaktPQnpxTWZySnczbkUKu0v3wJ2KmaWi2u8wMB7OwGvUHiVFuavM\nFDt9iHDCUUB5DwwDtujPYyhDoTCAc7Feviw+gf2eMJgeJ8azxGnSJA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-05-27T16:43:56Z",
+		"mac": "ENC[AES256_GCM,data:4EDUAuKPvxjh9QDutRwhvYwC0mkmOtnePH1NO3scGsrUlTi0bksdu9fdydzSvvuZYPGeXbbaj1Io+WKd3nD3sjCritzVXw7WISepUYMP7FUw7DXneAF9T/eHDk90XcNOSrwhh5ef9uNYar78nIa44I+3+jLjckex17FuxvD//HI=,iv:L8r2/+GKbEGgZNLUV0fYcpUW0fxGvKv2osH/MXgiCvQ=,tag:GypYtqNPoTRIYJnbZLWguw==,type:str]",
+		"version": "3.12.1"
+	}
+}


### PR DESCRIPTION
## Summary

- **Script library**: Track `kac`, `kion-aws-cache`, `monitor-gh-run`, and `jira-my-tickets` in `chezmoi/dot_local/bin` and `lib` so these scripts survive machine loss and are version-controlled. Previously they existed only as live files with no repo source.
- **kac ensure**: Extend `kion-aws-cache` with an `ensure` command that loads credentials from cache, falling back to `gkion env` when stale. `gkion` already writes to `~/.cache/kion-aws-cache/` (via `write_files=true`), so the two tools naturally share state.
- **SOPS encryption**: Encrypt `~/.config/gkion/config.toml` and `~/.config/technitiumdns-cli/config.toml` as repo artifacts. The technitiumdns-cli config contained a plaintext admin password and auth token. Both are deployed at activation via new `home.activation` entries in `sops.nix`.
- **Agent instructions**: Document `~/.local/bin` helper scripts in `agent-defaults.md` (and all generated mirrors). Fix stale `kac ensure` reference that referenced a command that didn't exist yet.
- **Pre-commit fix**: Unset `$TMPDIR` before inner `nix shell` invocations in `.githooks/pre-commit` to prevent `mktemp` failures when the hook runs inside a nix-managed shell (e.g. Claude Code).

## Test Plan

- [ ] `task check` passes (flake evaluation clean)
- [ ] `task lint:nix` passes (statix, deadnix, instruction sync checks)
- [ ] `sops --decrypt secrets/gkion.toml` produces valid TOML matching `~/.config/gkion/config.toml`
- [ ] `sops --decrypt secrets/technitiumdns-cli.toml` produces valid TOML matching `~/.config/technitiumdns-cli/config.toml`
- [ ] After `home-manager switch`: `~/.config/gkion/config.toml` and `~/.config/technitiumdns-cli/config.toml` exist with mode 600
- [ ] `source ~/.local/bin/kac ensure` loads credentials (or prompts via gkion if cache is empty)