### PR TITLE
feat(tooling): lazygit/delta/gron/gh-dash + directive tool-preference rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,18 +65,34 @@
 ## Shared Tooling Defaults
 
 - The shared package set in home-manager/common.nix usually provides these CLI
-  tools on managed hosts: git, gh, curl, wget, gcc, go, gopls, govulncheck,
+  tools on managed hosts: git, gh, gh-dash, lazygit, delta, curl, wget, gcc, go, gopls, govulncheck,
   delve (`dlv`), go-task (`task`), pkg-config, python3, pipx, maven, awscli2,
   awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose,
   overmind, bat, eza, fzf, fd, ripgrep (`rg`), sd, jq, yq-go (`yq`), zoxide,
-  direnv, dasel, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
+  direnv, dasel, gron, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
   ncdu, statix, deadnix, nixd, markdownlint-cli2, ruff, shellcheck, shfmt,
   yamllint, taplo, unison, glow, gum, tealdeer, scrcpy, cowsay, file, which,
   tree, rsync, btop, and lsof.
-- Prefer these repo-managed tools over generic fallbacks when they fit the task:
-  `rg` over `grep`, `fd` over `find`, `jq`/`yq`/`dasel` for structured data,
-  `task` for repository workflows, and `alejandra`/`statix`/`deadnix` for Nix
-  formatting and linting.
+- **Default to the modern tool; the legacy one is the exception, not the
+  habit.** Reach for the repo-provided replacement first on every command —
+  using `grep`/`find`/`cat`/`sed` out of reflex is the most common avoidable
+  inefficiency here, and these replacements are already installed:
+  - `rg` instead of `grep`, including from a pipe (`… | rg pattern`). Use
+    `grep` only for `git grep`.
+  - `fd` instead of `find` — it covers name/type/extension/`-x` exec. Fall back
+    to `find` only for predicates `fd` lacks (e.g. `-newermt`, complex `-exec`).
+  - `bat` for viewing a file; `/bin/cat` for raw bytes or piping a file into a
+    tool; never plain `cat` into a pager.
+  - `sd` for find-and-replace; reserve `sed` for committed scripts that need
+    POSIX portability (e.g. the render step in `taskfile.yaml`). To edit a
+    file, prefer the Edit/Write tools over `sed` or a `cat` heredoc.
+  - `jq`/`yq`/`dasel` for structured data — `gron` to make JSON greppable when
+    the shape is unknown; `task` for repo workflows; `alejandra`/`statix`/
+    `deadnix` for Nix.
+  - `lazygit` for interactive staging/diff review, `delta` is the configured
+    git pager, `gh-dash` for a PR/issue dashboard.
+  `cache-scan` and the `~/.cache/copilot` logs surface when the fallback crept
+  back in.
 - Treat this tool list as the default expected environment for repo work, but
   verify availability with `command -v` when portability matters because
   home-manager/common.nix still filters packages by host support.

--- a/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
@@ -68,18 +68,34 @@ applyTo: "**"
 ## Shared Tooling Defaults
 
 - The shared package set in home-manager/common.nix usually provides these CLI
-  tools on managed hosts: git, gh, curl, wget, gcc, go, gopls, govulncheck,
+  tools on managed hosts: git, gh, gh-dash, lazygit, delta, curl, wget, gcc, go, gopls, govulncheck,
   delve (`dlv`), go-task (`task`), pkg-config, python3, pipx, maven, awscli2,
   awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose,
   overmind, bat, eza, fzf, fd, ripgrep (`rg`), sd, jq, yq-go (`yq`), zoxide,
-  direnv, dasel, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
+  direnv, dasel, gron, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
   ncdu, statix, deadnix, nixd, markdownlint-cli2, ruff, shellcheck, shfmt,
   yamllint, taplo, unison, glow, gum, tealdeer, scrcpy, cowsay, file, which,
   tree, rsync, btop, and lsof.
-- Prefer these repo-managed tools over generic fallbacks when they fit the task:
-  `rg` over `grep`, `fd` over `find`, `jq`/`yq`/`dasel` for structured data,
-  `task` for repository workflows, and `alejandra`/`statix`/`deadnix` for Nix
-  formatting and linting.
+- **Default to the modern tool; the legacy one is the exception, not the
+  habit.** Reach for the repo-provided replacement first on every command —
+  using `grep`/`find`/`cat`/`sed` out of reflex is the most common avoidable
+  inefficiency here, and these replacements are already installed:
+  - `rg` instead of `grep`, including from a pipe (`… | rg pattern`). Use
+    `grep` only for `git grep`.
+  - `fd` instead of `find` — it covers name/type/extension/`-x` exec. Fall back
+    to `find` only for predicates `fd` lacks (e.g. `-newermt`, complex `-exec`).
+  - `bat` for viewing a file; `/bin/cat` for raw bytes or piping a file into a
+    tool; never plain `cat` into a pager.
+  - `sd` for find-and-replace; reserve `sed` for committed scripts that need
+    POSIX portability (e.g. the render step in `taskfile.yaml`). To edit a
+    file, prefer the Edit/Write tools over `sed` or a `cat` heredoc.
+  - `jq`/`yq`/`dasel` for structured data — `gron` to make JSON greppable when
+    the shape is unknown; `task` for repo workflows; `alejandra`/`statix`/
+    `deadnix` for Nix.
+  - `lazygit` for interactive staging/diff review, `delta` is the configured
+    git pager, `gh-dash` for a PR/issue dashboard.
+  `cache-scan` and the `~/.cache/copilot` logs surface when the fallback crept
+  back in.
 - Treat this tool list as the default expected environment for repo work, but
   verify availability with `command -v` when portability matters because
   home-manager/common.nix still filters packages by host support.

--- a/chezmoi/dot_config/claude/CLAUDE.md
+++ b/chezmoi/dot_config/claude/CLAUDE.md
@@ -65,18 +65,34 @@
 ## Shared Tooling Defaults
 
 - The shared package set in home-manager/common.nix usually provides these CLI
-  tools on managed hosts: git, gh, curl, wget, gcc, go, gopls, govulncheck,
+  tools on managed hosts: git, gh, gh-dash, lazygit, delta, curl, wget, gcc, go, gopls, govulncheck,
   delve (`dlv`), go-task (`task`), pkg-config, python3, pipx, maven, awscli2,
   awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose,
   overmind, bat, eza, fzf, fd, ripgrep (`rg`), sd, jq, yq-go (`yq`), zoxide,
-  direnv, dasel, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
+  direnv, dasel, gron, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
   ncdu, statix, deadnix, nixd, markdownlint-cli2, ruff, shellcheck, shfmt,
   yamllint, taplo, unison, glow, gum, tealdeer, scrcpy, cowsay, file, which,
   tree, rsync, btop, and lsof.
-- Prefer these repo-managed tools over generic fallbacks when they fit the task:
-  `rg` over `grep`, `fd` over `find`, `jq`/`yq`/`dasel` for structured data,
-  `task` for repository workflows, and `alejandra`/`statix`/`deadnix` for Nix
-  formatting and linting.
+- **Default to the modern tool; the legacy one is the exception, not the
+  habit.** Reach for the repo-provided replacement first on every command —
+  using `grep`/`find`/`cat`/`sed` out of reflex is the most common avoidable
+  inefficiency here, and these replacements are already installed:
+  - `rg` instead of `grep`, including from a pipe (`… | rg pattern`). Use
+    `grep` only for `git grep`.
+  - `fd` instead of `find` — it covers name/type/extension/`-x` exec. Fall back
+    to `find` only for predicates `fd` lacks (e.g. `-newermt`, complex `-exec`).
+  - `bat` for viewing a file; `/bin/cat` for raw bytes or piping a file into a
+    tool; never plain `cat` into a pager.
+  - `sd` for find-and-replace; reserve `sed` for committed scripts that need
+    POSIX portability (e.g. the render step in `taskfile.yaml`). To edit a
+    file, prefer the Edit/Write tools over `sed` or a `cat` heredoc.
+  - `jq`/`yq`/`dasel` for structured data — `gron` to make JSON greppable when
+    the shape is unknown; `task` for repo workflows; `alejandra`/`statix`/
+    `deadnix` for Nix.
+  - `lazygit` for interactive staging/diff review, `delta` is the configured
+    git pager, `gh-dash` for a PR/issue dashboard.
+  `cache-scan` and the `~/.cache/claude` logs surface when the fallback crept
+  back in.
 - Treat this tool list as the default expected environment for repo work, but
   verify availability with `command -v` when portability matters because
   home-manager/common.nix still filters packages by host support.

--- a/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
@@ -68,18 +68,34 @@ applyTo: "**"
 ## Shared Tooling Defaults
 
 - The shared package set in home-manager/common.nix usually provides these CLI
-  tools on managed hosts: git, gh, curl, wget, gcc, go, gopls, govulncheck,
+  tools on managed hosts: git, gh, gh-dash, lazygit, delta, curl, wget, gcc, go, gopls, govulncheck,
   delve (`dlv`), go-task (`task`), pkg-config, python3, pipx, maven, awscli2,
   awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose,
   overmind, bat, eza, fzf, fd, ripgrep (`rg`), sd, jq, yq-go (`yq`), zoxide,
-  direnv, dasel, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
+  direnv, dasel, gron, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
   ncdu, statix, deadnix, nixd, markdownlint-cli2, ruff, shellcheck, shfmt,
   yamllint, taplo, unison, glow, gum, tealdeer, scrcpy, cowsay, file, which,
   tree, rsync, btop, and lsof.
-- Prefer these repo-managed tools over generic fallbacks when they fit the task:
-  `rg` over `grep`, `fd` over `find`, `jq`/`yq`/`dasel` for structured data,
-  `task` for repository workflows, and `alejandra`/`statix`/`deadnix` for Nix
-  formatting and linting.
+- **Default to the modern tool; the legacy one is the exception, not the
+  habit.** Reach for the repo-provided replacement first on every command —
+  using `grep`/`find`/`cat`/`sed` out of reflex is the most common avoidable
+  inefficiency here, and these replacements are already installed:
+  - `rg` instead of `grep`, including from a pipe (`… | rg pattern`). Use
+    `grep` only for `git grep`.
+  - `fd` instead of `find` — it covers name/type/extension/`-x` exec. Fall back
+    to `find` only for predicates `fd` lacks (e.g. `-newermt`, complex `-exec`).
+  - `bat` for viewing a file; `/bin/cat` for raw bytes or piping a file into a
+    tool; never plain `cat` into a pager.
+  - `sd` for find-and-replace; reserve `sed` for committed scripts that need
+    POSIX portability (e.g. the render step in `taskfile.yaml`). To edit a
+    file, prefer the Edit/Write tools over `sed` or a `cat` heredoc.
+  - `jq`/`yq`/`dasel` for structured data — `gron` to make JSON greppable when
+    the shape is unknown; `task` for repo workflows; `alejandra`/`statix`/
+    `deadnix` for Nix.
+  - `lazygit` for interactive staging/diff review, `delta` is the configured
+    git pager, `gh-dash` for a PR/issue dashboard.
+  `cache-scan` and the `~/.cache/copilot` logs surface when the fallback crept
+  back in.
 - Treat this tool list as the default expected environment for repo work, but
   verify availability with `command -v` when portability matters because
   home-manager/common.nix still filters packages by host support.

--- a/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
+++ b/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
@@ -68,18 +68,34 @@ applyTo: "**"
 ## Shared Tooling Defaults
 
 - The shared package set in home-manager/common.nix usually provides these CLI
-  tools on managed hosts: git, gh, curl, wget, gcc, go, gopls, govulncheck,
+  tools on managed hosts: git, gh, gh-dash, lazygit, delta, curl, wget, gcc, go, gopls, govulncheck,
   delve (`dlv`), go-task (`task`), pkg-config, python3, pipx, maven, awscli2,
   awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose,
   overmind, bat, eza, fzf, fd, ripgrep (`rg`), sd, jq, yq-go (`yq`), zoxide,
-  direnv, dasel, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
+  direnv, dasel, gron, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
   ncdu, statix, deadnix, nixd, markdownlint-cli2, ruff, shellcheck, shfmt,
   yamllint, taplo, unison, glow, gum, tealdeer, scrcpy, cowsay, file, which,
   tree, rsync, btop, and lsof.
-- Prefer these repo-managed tools over generic fallbacks when they fit the task:
-  `rg` over `grep`, `fd` over `find`, `jq`/`yq`/`dasel` for structured data,
-  `task` for repository workflows, and `alejandra`/`statix`/`deadnix` for Nix
-  formatting and linting.
+- **Default to the modern tool; the legacy one is the exception, not the
+  habit.** Reach for the repo-provided replacement first on every command —
+  using `grep`/`find`/`cat`/`sed` out of reflex is the most common avoidable
+  inefficiency here, and these replacements are already installed:
+  - `rg` instead of `grep`, including from a pipe (`… | rg pattern`). Use
+    `grep` only for `git grep`.
+  - `fd` instead of `find` — it covers name/type/extension/`-x` exec. Fall back
+    to `find` only for predicates `fd` lacks (e.g. `-newermt`, complex `-exec`).
+  - `bat` for viewing a file; `/bin/cat` for raw bytes or piping a file into a
+    tool; never plain `cat` into a pager.
+  - `sd` for find-and-replace; reserve `sed` for committed scripts that need
+    POSIX portability (e.g. the render step in `taskfile.yaml`). To edit a
+    file, prefer the Edit/Write tools over `sed` or a `cat` heredoc.
+  - `jq`/`yq`/`dasel` for structured data — `gron` to make JSON greppable when
+    the shape is unknown; `task` for repo workflows; `alejandra`/`statix`/
+    `deadnix` for Nix.
+  - `lazygit` for interactive staging/diff review, `delta` is the configured
+    git pager, `gh-dash` for a PR/issue dashboard.
+  `cache-scan` and the `~/.cache/copilot` logs surface when the fallback crept
+  back in.
 - Treat this tool list as the default expected environment for repo work, but
   verify availability with `command -v` when portability matters because
   home-manager/common.nix still filters packages by host support.

--- a/chezmoi/dot_config/instructions/agent-defaults.md
+++ b/chezmoi/dot_config/instructions/agent-defaults.md
@@ -65,18 +65,34 @@
 ## Shared Tooling Defaults
 
 - The shared package set in home-manager/common.nix usually provides these CLI
-  tools on managed hosts: git, gh, curl, wget, gcc, go, gopls, govulncheck,
+  tools on managed hosts: git, gh, gh-dash, lazygit, delta, curl, wget, gcc, go, gopls, govulncheck,
   delve (`dlv`), go-task (`task`), pkg-config, python3, pipx, maven, awscli2,
   awslogs, aws-sam-cli, checkov, bun, docker, docker-buildx, docker-compose,
   overmind, bat, eza, fzf, fd, ripgrep (`rg`), sd, jq, yq-go (`yq`), zoxide,
-  direnv, dasel, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
+  direnv, dasel, gron, tmux, age, zstd, unzip, p7zip (`7z`/`7za`/`7zr`), alejandra,
   ncdu, statix, deadnix, nixd, markdownlint-cli2, ruff, shellcheck, shfmt,
   yamllint, taplo, unison, glow, gum, tealdeer, scrcpy, cowsay, file, which,
   tree, rsync, btop, and lsof.
-- Prefer these repo-managed tools over generic fallbacks when they fit the task:
-  `rg` over `grep`, `fd` over `find`, `jq`/`yq`/`dasel` for structured data,
-  `task` for repository workflows, and `alejandra`/`statix`/`deadnix` for Nix
-  formatting and linting.
+- **Default to the modern tool; the legacy one is the exception, not the
+  habit.** Reach for the repo-provided replacement first on every command —
+  using `grep`/`find`/`cat`/`sed` out of reflex is the most common avoidable
+  inefficiency here, and these replacements are already installed:
+  - `rg` instead of `grep`, including from a pipe (`… | rg pattern`). Use
+    `grep` only for `git grep`.
+  - `fd` instead of `find` — it covers name/type/extension/`-x` exec. Fall back
+    to `find` only for predicates `fd` lacks (e.g. `-newermt`, complex `-exec`).
+  - `bat` for viewing a file; `/bin/cat` for raw bytes or piping a file into a
+    tool; never plain `cat` into a pager.
+  - `sd` for find-and-replace; reserve `sed` for committed scripts that need
+    POSIX portability (e.g. the render step in `taskfile.yaml`). To edit a
+    file, prefer the Edit/Write tools over `sed` or a `cat` heredoc.
+  - `jq`/`yq`/`dasel` for structured data — `gron` to make JSON greppable when
+    the shape is unknown; `task` for repo workflows; `alejandra`/`statix`/
+    `deadnix` for Nix.
+  - `lazygit` for interactive staging/diff review, `delta` is the configured
+    git pager, `gh-dash` for a PR/issue dashboard.
+  `cache-scan` and the `~/.cache/@@AGENT@@` logs surface when the fallback crept
+  back in.
 - Treat this tool list as the default expected environment for repo work, but
   verify availability with `command -v` when portability matters because
   home-manager/common.nix still filters packages by host support.

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -75,6 +75,9 @@
     # Version control
     git
     gh
+    gh-dash # TUI dashboard for GitHub PRs/issues
+    lazygit # TUI for fast hunk-level staging, diff/log/branch navigation
+    delta # syntax-highlighting pager for git diffs (wired as core.pager below)
 
     # Network
     curl
@@ -127,6 +130,7 @@
     jq
     yq-go
     dasel
+    gron # flatten JSON into greppable assignment lines (and back)
 
     # Nix tooling
     alejandra
@@ -653,8 +657,19 @@ in {
           email = "jhettenh@gmail.com";
         };
         init.defaultBranch = "main";
-        core.editor = "vim";
+        core = {
+          editor = "vim";
+          pager = "delta";
+        };
         pull.rebase = false;
+        # delta: syntax-highlighted diffs/pager. `delta` package added above.
+        interactive.diffFilter = "delta --color-only";
+        delta = {
+          navigate = true; # n/N to move between diff hunks
+          line-numbers = true;
+        };
+        merge.conflictStyle = "zdiff3";
+        diff.colorMoved = "default";
       };
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #48 (which merged the CI fix + log tooling). This adds the CLI tools and the agent tool-preference rule that were prepared alongside that work but didn't make it into the merge. Diff is tooling-only — it branches from the commit already in `main`.

### New tools (shared package set, `home-manager/common.nix`)

Grounded in cache-log analysis of ~3,000 logged commands (git `diff/add/log/show` and `gh` dominate):

- **lazygit** — TUI for fast hunk-level staging and diff/log/branch review.
- **delta** — syntax-highlighting git pager, wired as `core.pager` + `interactive.diffFilter`, with `navigate`, `line-numbers`, `merge.conflictStyle = zdiff3`, and `diff.colorMoved = default`.
- **gron** — flatten JSON into greppable assignment lines (and back).
- **gh-dash** — TUI dashboard for GitHub PRs/issues.

### The "free lever" — agent tool-preference rule

The cache logs showed the modern tools already installed were bypassed for legacy ones (`grep` 401 vs `rg` 117, `find` 72 vs `fd` 67, heavy `cat`/`sed`). Rewrote the `Shared Tooling Defaults` bullet in `agent-defaults.md` from a soft "prefer" into a **directive default-tool rule** with explicit, legitimate exceptions so agents don't overcorrect and break things:

- `rg`▸`grep` (except `git grep`), `fd`▸`find` (except `-newermt`/complex `-exec`), `bat`/`​/bin/cat`▸`cat`, `sd`▸`sed` (reserve `sed` for POSIX scripts like the `taskfile.yaml` render step).
- Points at `cache-scan` + the `~/.cache/<agent>` logs as the way to spot regressions.

All rendered mirrors + `.github/copilot-instructions.md` regenerated; the existing `Co-Authored-By` instruction is preserved in source and mirrors.

## Verification

- `task fmt:check` ✅, `task lint:nix` ✅ (statix, deadnix, both instruction-sync checks)
- `nix eval` confirmed all four packages resolve in the pin and delta is wired (`core.pager = delta`, `diffFilter = delta --color-only`)
- This branch already passed the full Nix Validation matrix as PR #48's second commit before #48 was merged early.

## Note

A `home-switch` applies the new packages and the delta git config.
