### PR TITLE
feat(tooling): agent reasoning capture + token-lean cache-scan + coreutils priority

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -173,13 +173,13 @@ they fit the task.
     secrets on disk and token-shaped strings are redacted before write, files
     are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
     Treat these logs as sensitive regardless.
-- **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
-  `log-bash.sh` records and prints a per-session overview (command / stderr /
-  interrupt counts, last status), a recent-command timeline, the commands that
-  hit stderr or were interrupted, and a heuristic keyword scan. Flags:
-  `--days N` (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`.
-  De-duplicates the `~/.cache/claude → ~/.cache/copilot` symlink. Prefer this
-  over hand-rolled `rg` sweeps of the log dir.
+- **`cache-scan`** — Scan the agent log dir for recent activity. **Terse by
+  default** (token-lean, since an agent reads it): a one-line-per-session
+  overview plus the commands that hit stderr or were interrupted. `-v|--verbose`
+  adds the command timeline and heuristic keyword scan. Flags: `--days N`
+  (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`, `-v|--verbose`.
+  De-duplicates the `~/.cache/copilot` symlink. Prefer this over hand-rolled
+  `rg` sweeps of the log dir.
 - **`ops-agent`** — Deployed via `home-manager/common.nix` as
   `writeShellScriptBin` (source `home-manager/scripts/ops-agent.py`).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -161,6 +161,18 @@ they fit the task.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
+  Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
+  new reasoning to `~/.cache/copilot/session_<id>.thinking.log`, deduped by a
+  per-source line cursor. Sources differ per agent: Claude's session transcript
+  (`thinking` blocks) and Copilot's `events.jsonl` (`data.reasoningText`).
+  - **Best-effort for Claude**: thinking text is captured when persisted, but
+    some turns/sessions (e.g. fast mode) store only the encrypted `signature`
+    with empty text — those are skipped, not an error.
+  - **Security**: reasoning can contain secret *values* the agent saw. Known
+    secrets on disk and token-shaped strings are redacted before write, files
+    are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
+    Treat these logs as sensitive regardless.
 - **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
   `log-bash.sh` records and prints a per-session overview (command / stderr /
   interrupt counts, last status), a recent-command timeline, the commands that

--- a/README.md
+++ b/README.md
@@ -269,6 +269,29 @@ task generate:agent-instructions
 
 The pre-commit hook and CI catch drift automatically via `task check:agent-instructions`.
 
+### Agent activity logs & `cache-scan`
+
+Agent sessions are logged to `~/.cache/<agent>/` (with `~/.cache/claude` symlinked
+to `~/.cache/copilot` so both share one dir) by hooks deployed from
+`chezmoi/dot_local/bin/`:
+
+| Script | Hook | Captures → file |
+|---|---|---|
+| `log-bash.sh` | Bash `PostToolUse` | each command + stdout/stderr → `session_<id>.log` (`## [ts] status=ok\|stderr\|interrupted cwd=…`) |
+| `log-thinking.sh` | Claude `Stop`/`SubagentStop`, Copilot `postToolUse` | agent reasoning → `session_<id>.thinking.log` (best-effort for Claude) |
+| `claude-cache-stats` | Claude `SessionEnd` | one-line prompt-cache-hit summary → `cache-stats.log` |
+
+Read it back with **`cache-scan`** — terse by default (one line per session plus
+the commands that hit stderr/were interrupted), `--verbose` adds the command
+timeline and a keyword scan. Flags: `--days N` (default 2), `--date`,
+`--session ID`, `--limit N`, `-v|--verbose`. Output is kept token-lean because an
+agent consumes it. The scripts assume GNU coreutils (`stat -c`), guaranteed by
+`coreutils` in the darwin system profile (native on Linux/WSL).
+
+**Security:** `*.thinking.log` can contain secret *values* the agent reasoned
+about; reasoning logs redact known secrets, are written `0600`, and are excluded
+from the gdrive sync profile. Treat the cache logs as sensitive.
+
 ## AI Tooling (Skills + Agents)
 
 Custom skills and agents live in [`ai-tools/`](ai-tools/) as the single source of truth, modeled on the

--- a/ai-tools/skills/ops-cache-scan/SKILL.md
+++ b/ai-tools/skills/ops-cache-scan/SKILL.md
@@ -26,25 +26,29 @@ This is *not* something a session needs to wire up — if the host has had `home
 - `--days N` lookback by file mtime (defaults to `2`).
 - `--date YYYY-MM-DD` to restrict records to a header date.
 - `--session ID` to focus a single session log.
-- `--limit N` recent-command timeline length (defaults to `15`).
+- `--limit N` timeline length under `--verbose` (defaults to `10`).
+- `-v|--verbose` add the command timeline and keyword scan (default output is
+  intentionally terse to keep token cost low — read the default first and only
+  reach for `--verbose` when you need the full timeline).
 
 ## Procedure
 
-1. Run the helper script:
-   `cache-scan`
-2. For a wider lookback:
-   `cache-scan --days 5`
-3. For a single session:
-   `cache-scan --session 4e8838e2`
+1. Run the helper script (terse): `cache-scan`
+2. Wider lookback: `cache-scan --days 5`
+3. Single session, full detail: `cache-scan --session 4e8838e2 --verbose`
 
 ## What To Extract
 
-`cache-scan` already structures most of this; read its sections directly:
+`cache-scan` already structures this; read its sections directly:
 
-- **Sessions** — per-session command / stderr / interrupt counts and last status.
-- **Recent commands** — the timeline (`[ts] status :: cmd`) from the newest session; the tail is where work was interrupted.
-- **Likely failures** — commands with `status=stderr|interrupted`; these are the concrete resume points.
-- **Keyword hits** — heuristic backstop for errors a `status=ok` line missed (and for pre-structured logs).
+- **SESSIONS** (default) — one line per session: id, command / stderr / interrupt
+  counts, last status + command.
+- **FAILURES** (default) — commands with `status=stderr|interrupted`; the concrete
+  resume points.
+- **TIMELINE** (`--verbose`) — `[ts] status :: cmd` from the newest session; the
+  tail is where work was interrupted.
+- **KEYWORD HITS** (`--verbose`) — heuristic backstop for errors a `status=ok`
+  line missed (and for pre-structured logs).
 
 ## Output Contract
 

--- a/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
@@ -164,6 +164,18 @@ they fit the task.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
+  Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
+  new reasoning to `~/.cache/copilot/session_<id>.thinking.log`, deduped by a
+  per-source line cursor. Sources differ per agent: Claude's session transcript
+  (`thinking` blocks) and Copilot's `events.jsonl` (`data.reasoningText`).
+  - **Best-effort for Claude**: thinking text is captured when persisted, but
+    some turns/sessions (e.g. fast mode) store only the encrypted `signature`
+    with empty text — those are skipped, not an error.
+  - **Security**: reasoning can contain secret *values* the agent saw. Known
+    secrets on disk and token-shaped strings are redacted before write, files
+    are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
+    Treat these logs as sensitive regardless.
 - **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
   `log-bash.sh` records and prints a per-session overview (command / stderr /
   interrupt counts, last status), a recent-command timeline, the commands that

--- a/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
@@ -176,13 +176,13 @@ they fit the task.
     secrets on disk and token-shaped strings are redacted before write, files
     are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
     Treat these logs as sensitive regardless.
-- **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
-  `log-bash.sh` records and prints a per-session overview (command / stderr /
-  interrupt counts, last status), a recent-command timeline, the commands that
-  hit stderr or were interrupted, and a heuristic keyword scan. Flags:
-  `--days N` (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`.
-  De-duplicates the `~/.cache/claude → ~/.cache/copilot` symlink. Prefer this
-  over hand-rolled `rg` sweeps of the log dir.
+- **`cache-scan`** — Scan the agent log dir for recent activity. **Terse by
+  default** (token-lean, since an agent reads it): a one-line-per-session
+  overview plus the commands that hit stderr or were interrupted. `-v|--verbose`
+  adds the command timeline and heuristic keyword scan. Flags: `--days N`
+  (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`, `-v|--verbose`.
+  De-duplicates the `~/.cache/copilot` symlink. Prefer this over hand-rolled
+  `rg` sweeps of the log dir.
 - **`ops-agent`** — Deployed via `home-manager/common.nix` as
   `writeShellScriptBin` (source `home-manager/scripts/ops-agent.py`).
 

--- a/chezmoi/dot_config/claude/CLAUDE.md
+++ b/chezmoi/dot_config/claude/CLAUDE.md
@@ -161,6 +161,18 @@ they fit the task.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
+  Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
+  new reasoning to `~/.cache/claude/session_<id>.thinking.log`, deduped by a
+  per-source line cursor. Sources differ per agent: Claude's session transcript
+  (`thinking` blocks) and Copilot's `events.jsonl` (`data.reasoningText`).
+  - **Best-effort for Claude**: thinking text is captured when persisted, but
+    some turns/sessions (e.g. fast mode) store only the encrypted `signature`
+    with empty text — those are skipped, not an error.
+  - **Security**: reasoning can contain secret *values* the agent saw. Known
+    secrets on disk and token-shaped strings are redacted before write, files
+    are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
+    Treat these logs as sensitive regardless.
 - **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
   `log-bash.sh` records and prints a per-session overview (command / stderr /
   interrupt counts, last status), a recent-command timeline, the commands that

--- a/chezmoi/dot_config/claude/CLAUDE.md
+++ b/chezmoi/dot_config/claude/CLAUDE.md
@@ -173,13 +173,13 @@ they fit the task.
     secrets on disk and token-shaped strings are redacted before write, files
     are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
     Treat these logs as sensitive regardless.
-- **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
-  `log-bash.sh` records and prints a per-session overview (command / stderr /
-  interrupt counts, last status), a recent-command timeline, the commands that
-  hit stderr or were interrupted, and a heuristic keyword scan. Flags:
-  `--days N` (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`.
-  De-duplicates the `~/.cache/claude → ~/.cache/copilot` symlink. Prefer this
-  over hand-rolled `rg` sweeps of the log dir.
+- **`cache-scan`** — Scan the agent log dir for recent activity. **Terse by
+  default** (token-lean, since an agent reads it): a one-line-per-session
+  overview plus the commands that hit stderr or were interrupted. `-v|--verbose`
+  adds the command timeline and heuristic keyword scan. Flags: `--days N`
+  (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`, `-v|--verbose`.
+  De-duplicates the `~/.cache/claude` symlink. Prefer this over hand-rolled
+  `rg` sweeps of the log dir.
 - **`ops-agent`** — Deployed via `home-manager/common.nix` as
   `writeShellScriptBin` (source `home-manager/scripts/ops-agent.py`).
 

--- a/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
@@ -164,6 +164,18 @@ they fit the task.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
+  Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
+  new reasoning to `~/.cache/copilot/session_<id>.thinking.log`, deduped by a
+  per-source line cursor. Sources differ per agent: Claude's session transcript
+  (`thinking` blocks) and Copilot's `events.jsonl` (`data.reasoningText`).
+  - **Best-effort for Claude**: thinking text is captured when persisted, but
+    some turns/sessions (e.g. fast mode) store only the encrypted `signature`
+    with empty text — those are skipped, not an error.
+  - **Security**: reasoning can contain secret *values* the agent saw. Known
+    secrets on disk and token-shaped strings are redacted before write, files
+    are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
+    Treat these logs as sensitive regardless.
 - **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
   `log-bash.sh` records and prints a per-session overview (command / stderr /
   interrupt counts, last status), a recent-command timeline, the commands that

--- a/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
@@ -176,13 +176,13 @@ they fit the task.
     secrets on disk and token-shaped strings are redacted before write, files
     are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
     Treat these logs as sensitive regardless.
-- **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
-  `log-bash.sh` records and prints a per-session overview (command / stderr /
-  interrupt counts, last status), a recent-command timeline, the commands that
-  hit stderr or were interrupted, and a heuristic keyword scan. Flags:
-  `--days N` (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`.
-  De-duplicates the `~/.cache/claude → ~/.cache/copilot` symlink. Prefer this
-  over hand-rolled `rg` sweeps of the log dir.
+- **`cache-scan`** — Scan the agent log dir for recent activity. **Terse by
+  default** (token-lean, since an agent reads it): a one-line-per-session
+  overview plus the commands that hit stderr or were interrupted. `-v|--verbose`
+  adds the command timeline and heuristic keyword scan. Flags: `--days N`
+  (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`, `-v|--verbose`.
+  De-duplicates the `~/.cache/copilot` symlink. Prefer this over hand-rolled
+  `rg` sweeps of the log dir.
 - **`ops-agent`** — Deployed via `home-manager/common.nix` as
   `writeShellScriptBin` (source `home-manager/scripts/ops-agent.py`).
 

--- a/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
+++ b/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
@@ -164,6 +164,18 @@ they fit the task.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
+  Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
+  new reasoning to `~/.cache/copilot/session_<id>.thinking.log`, deduped by a
+  per-source line cursor. Sources differ per agent: Claude's session transcript
+  (`thinking` blocks) and Copilot's `events.jsonl` (`data.reasoningText`).
+  - **Best-effort for Claude**: thinking text is captured when persisted, but
+    some turns/sessions (e.g. fast mode) store only the encrypted `signature`
+    with empty text — those are skipped, not an error.
+  - **Security**: reasoning can contain secret *values* the agent saw. Known
+    secrets on disk and token-shaped strings are redacted before write, files
+    are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
+    Treat these logs as sensitive regardless.
 - **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
   `log-bash.sh` records and prints a per-session overview (command / stderr /
   interrupt counts, last status), a recent-command timeline, the commands that

--- a/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
+++ b/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
@@ -176,13 +176,13 @@ they fit the task.
     secrets on disk and token-shaped strings are redacted before write, files
     are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
     Treat these logs as sensitive regardless.
-- **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
-  `log-bash.sh` records and prints a per-session overview (command / stderr /
-  interrupt counts, last status), a recent-command timeline, the commands that
-  hit stderr or were interrupted, and a heuristic keyword scan. Flags:
-  `--days N` (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`.
-  De-duplicates the `~/.cache/claude → ~/.cache/copilot` symlink. Prefer this
-  over hand-rolled `rg` sweeps of the log dir.
+- **`cache-scan`** — Scan the agent log dir for recent activity. **Terse by
+  default** (token-lean, since an agent reads it): a one-line-per-session
+  overview plus the commands that hit stderr or were interrupted. `-v|--verbose`
+  adds the command timeline and heuristic keyword scan. Flags: `--days N`
+  (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`, `-v|--verbose`.
+  De-duplicates the `~/.cache/copilot` symlink. Prefer this over hand-rolled
+  `rg` sweeps of the log dir.
 - **`ops-agent`** — Deployed via `home-manager/common.nix` as
   `writeShellScriptBin` (source `home-manager/scripts/ops-agent.py`).
 

--- a/chezmoi/dot_config/instructions/agent-defaults.md
+++ b/chezmoi/dot_config/instructions/agent-defaults.md
@@ -161,6 +161,18 @@ they fit the task.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
+  Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
+  new reasoning to `~/.cache/@@AGENT@@/session_<id>.thinking.log`, deduped by a
+  per-source line cursor. Sources differ per agent: Claude's session transcript
+  (`thinking` blocks) and Copilot's `events.jsonl` (`data.reasoningText`).
+  - **Best-effort for Claude**: thinking text is captured when persisted, but
+    some turns/sessions (e.g. fast mode) store only the encrypted `signature`
+    with empty text — those are skipped, not an error.
+  - **Security**: reasoning can contain secret *values* the agent saw. Known
+    secrets on disk and token-shaped strings are redacted before write, files
+    are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
+    Treat these logs as sensitive regardless.
 - **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
   `log-bash.sh` records and prints a per-session overview (command / stderr /
   interrupt counts, last status), a recent-command timeline, the commands that

--- a/chezmoi/dot_config/instructions/agent-defaults.md
+++ b/chezmoi/dot_config/instructions/agent-defaults.md
@@ -173,13 +173,13 @@ they fit the task.
     secrets on disk and token-shaped strings are redacted before write, files
     are `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
     Treat these logs as sensitive regardless.
-- **`cache-scan`** — Scan the agent log dir for recent activity. Parses the
-  `log-bash.sh` records and prints a per-session overview (command / stderr /
-  interrupt counts, last status), a recent-command timeline, the commands that
-  hit stderr or were interrupted, and a heuristic keyword scan. Flags:
-  `--days N` (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`.
-  De-duplicates the `~/.cache/claude → ~/.cache/copilot` symlink. Prefer this
-  over hand-rolled `rg` sweeps of the log dir.
+- **`cache-scan`** — Scan the agent log dir for recent activity. **Terse by
+  default** (token-lean, since an agent reads it): a one-line-per-session
+  overview plus the commands that hit stderr or were interrupted. `-v|--verbose`
+  adds the command timeline and heuristic keyword scan. Flags: `--days N`
+  (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`, `-v|--verbose`.
+  De-duplicates the `~/.cache/@@AGENT@@` symlink. Prefer this over hand-rolled
+  `rg` sweeps of the log dir.
 - **`ops-agent`** — Deployed via `home-manager/common.nix` as
   `writeShellScriptBin` (source `home-manager/scripts/ops-agent.py`).
 

--- a/chezmoi/dot_config/unison/gdrive-dotfiles.prf
+++ b/chezmoi/dot_config/unison/gdrive-dotfiles.prf
@@ -50,6 +50,10 @@ ignore = Path .local/pipx
 ignore = Name .tmp.driveupload
 # Unison log files shouldn't be synced (avoid self-modification errors)
 ignore = Name unison-gdrive.log
+# Agent reasoning logs may contain secret VALUES the agent reasoned about; keep
+# them on local disk only (they live under .cache/<agent>, which IS synced).
+ignore = Name *.thinking.log
+ignore = Name .thinking-cursor
 ignore = Name .git
 ignore = Name .gitignore
 ignore = Name node_modules

--- a/chezmoi/dot_local/bin/executable_cache-scan
+++ b/chezmoi/dot_local/bin/executable_cache-scan
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
 # cache-scan — surface recent agent activity from the ~/.cache/<agent> log dir.
 #
-# Reads the structured per-session logs written by log-bash.sh and prints:
-#   - a per-session overview (command / stderr / interrupt counts, last status)
-#   - a timeline of the most recent commands with their status
-#   - the commands that produced stderr or were interrupted (likely failures)
-#   - a heuristic keyword scan of output text (catches errors a status=ok line
-#     would miss, and still works on pre-structured logs)
+# Reads the structured per-session logs written by log-bash.sh and prints a
+# compact, low-token summary by default: a one-line-per-session overview and the
+# commands that hit stderr or were interrupted. Pass --verbose for the
+# command timeline, the heuristic keyword scan, and un-abbreviated paths.
 #
-# log-bash.sh record format the parser keys on:
-#   ## [YYYY-MM-DD HH:MM:SS] status=ok|stderr|interrupted cwd=<dir>
-#   CMD: <command>
-#   STDOUT: / STDERR: sections
+# Output is deliberately terse — it is consumed by an agent, so every line costs
+# tokens. Keep the default lean; put detail behind --verbose.
+#
+# Assumes GNU coreutils (stat -c). Guaranteed on PATH by this nix config:
+# coreutils is in the darwin system profile and native on Linux/WSL.
 set -euo pipefail
 
 usage() {
 	cat <<'EOF'
-Usage: cache-scan [--days N] [--date YYYY-MM-DD] [--session ID] [--limit N]
+Usage: cache-scan [--days N] [--date YYYY-MM-DD] [--session ID] [--limit N] [-v|--verbose]
 
   --days N      Look back N days by file mtime (default: 2)
   --date DATE   Only show records whose header timestamp starts with DATE
   --session ID  Restrict to session log files matching ID
-  --limit N     Number of recent commands in the timeline (default: 15)
+  --limit N     Timeline length under --verbose (default: 10)
+  -v|--verbose  Add the command timeline, keyword scan, and full paths
 
 Scans the agent log dir (~/.cache/claude, symlinked to ~/.cache/copilot).
 EOF
@@ -30,7 +30,8 @@ EOF
 days=2
 date_filter=""
 session=""
-limit=15
+limit=10
+verbose=0
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -62,6 +63,9 @@ while [[ $# -gt 0 ]]; do
 			exit 1
 		}
 		;;
+	-v | --verbose)
+		verbose=1
+		;;
 	-h | --help)
 		usage
 		exit 0
@@ -91,94 +95,76 @@ if [[ ${#roots[@]} -eq 0 ]]; then
 	exit 0
 fi
 
-# mtime format args, detecting GNU (-c) vs BSD (-f) stat. Probe -c first: only
-# GNU supports it, so BSD falls through cleanly (BSD -f would otherwise be
-# misread as --file-system on GNU and print filesystem info).
-if stat -c '%Y' . >/dev/null 2>&1; then
-	statfmt=(-c '%Y')
-else
-	statfmt=(-f '%m')
-fi
-
-# Discover session logs (by mtime), newest first.
+# Discover session logs (by mtime, newest first). GNU stat (-c) — see header.
 name_glob='session_*.log'
 [[ -n "$session" ]] && name_glob="session_*${session}*.log"
 mapfile -t logs < <(find "${roots[@]}" -type f -name "$name_glob" -mtime "-$days" 2>/dev/null |
-	while read -r p; do printf '%s\t%s\n' "$(stat "${statfmt[@]}" "$p" 2>/dev/null || echo 0)" "$p"; done |
+	while read -r p; do printf '%s\t%s\n' "$(stat -c '%Y' "$p" 2>/dev/null || echo 0)" "$p"; done |
 	sort -rn | cut -f2-)
 
-short() { sed "s#$HOME#~#g"; }
-
-echo "== cache-scan =="
-echo "roots:    ${roots[*]/#$HOME/\~}"
-echo "lookback: ${days}d${date_filter:+   date~$date_filter}${session:+   session~$session}"
-echo "sessions: ${#logs[@]}"
-echo
+roots_disp="${roots[*]/#$HOME/\~}"
+printf 'cache-scan  roots=%s  lookback=%dd  sessions=%d%s\n' \
+	"$roots_disp" "$days" "${#logs[@]}" "${session:+  session~$session}"
 
 if [[ ${#logs[@]} -eq 0 ]]; then
-	echo "No session_*.log files in the last ${days} day(s)."
-	echo "(raise --days, or check that the log-bash.sh PostToolUse hook is wired)"
+	echo "(none in window; raise --days or check the log-bash PostToolUse hook)"
 	exit 0
 fi
 
-# awk program shared by the overview/timeline/failure passes. Extracts the
-# header timestamp and status, and the CMD that follows each header.
+# Shared header parser: pull the timestamp + status from a "## [...] status=" line.
 read -r -d '' AWK_HDR <<'AWK' || true
-function hdr(line,   s) {
+function hdr(line) {
 	match(line, /\[[0-9-]+ [0-9:]+\]/); stamp = substr(line, RSTART + 1, RLENGTH - 2)
 	st = "?"
 	if (match(line, /status=[a-z]+/)) st = substr(line, RSTART + 7, RLENGTH - 7)
 }
+function hhmmss(s) { return (match(s, /[0-9:]+$/)) ? substr(s, RSTART, RLENGTH) : s }
+function idof(f,   b) { b = f; sub(/^session_/, "", b); sub(/\.log$/, "", b); return substr(b, 1, 8) }
 AWK
 
-echo "== Sessions (newest first) =="
+# One line per session: id, counts, last status + command. (Was two lines —
+# halving it is the biggest default-output token saving.)
+echo "SESSIONS (newest first)"
 for f in "${logs[@]}"; do
 	awk -v file="${f##*/}" -v df="$date_filter" "$AWK_HDR"'
 		/^## \[/ { hdr($0); if (df != "" && index(stamp, df) != 1) { skip=1; next } skip=0
-			recs++; laststamp=stamp; laststatus=st
+			recs++; laststatus=st
 			if (st=="stderr") nerr++; else if (st=="interrupted") nint++; next }
 		/^CMD: / && !skip { lastcmd=substr($0,6) }
 		END {
 			if (recs==0) exit
-			c = (length(lastcmd)>64) ? substr(lastcmd,1,64) "…" : lastcmd
-			printf "  %-34s cmds=%-4d stderr=%-3d intr=%-3d  last[%s]=%s\n      └ %s\n", \
-				file, recs, nerr+0, nint+0, laststamp, laststatus, c
+			c = (length(lastcmd)>52) ? substr(lastcmd,1,52) "…" : lastcmd
+			printf "  %-8s cmds=%-3d err=%-2d intr=%-2d %-11s :: %s\n", \
+				idof(file), recs, nerr+0, nint+0, laststatus, c
 		}' "$f"
 done
-echo
+
+# Likely failures — compact (time-only stamp, capped). The high-signal section.
+echo "FAILURES (stderr|interrupted)"
+fail_out=$(for f in "${logs[@]}"; do
+	awk -v file="${f##*/}" "$AWK_HDR"'
+		/^## \[/ { hdr($0); bad=(st=="stderr"||st=="interrupted"); pstamp=stamp; pst=st; next }
+		/^CMD: / && bad { printf "  %-8s %s %-11s :: %s\n", idof(file), hhmmss(pstamp), pst, substr($0,6); bad=0 }
+	' "$f"
+done | tail -n 12)
+if [[ -n "$fail_out" ]]; then
+	printf '%s\n' "$fail_out"
+else
+	echo "  none"
+fi
+
+# Everything below is detail — verbose only, to keep the default token-cheap.
+((verbose)) || exit 0
 
 recent="${logs[0]}"
-echo "== Recent commands (last $limit, from ${recent##*/}) =="
+echo "TIMELINE (last $limit, ${recent##*/})"
 awk "$AWK_HDR"'
 	/^## \[/ { hdr($0); pstamp=stamp; pst=st; pend=1; next }
 	/^CMD: / && pend { printf "  [%s] %-11s %s\n", pstamp, pst, substr($0,6); pend=0 }
 ' "$recent" | tail -n "$limit"
-echo
 
-echo "== Likely failures (status=stderr|interrupted) =="
-fail_out=$(for f in "${logs[@]}"; do
-	awk -v file="${f##*/}" "$AWK_HDR"'
-		/^## \[/ { hdr($0); bad=(st=="stderr"||st=="interrupted"); pstamp=stamp; pst=st; next }
-		/^CMD: / && bad { printf "  %-30s [%s] %-11s %s\n", file, pstamp, pst, substr($0,6); bad=0 }
-	' "$f"
-done | tail -n 40)
-if [[ -n "$fail_out" ]]; then
-	printf '%s\n' "$fail_out"
-else
-	echo "  none in window (or logs predate structured status headers)"
-fi
-echo
-
-echo "== Keyword hits in output text (heuristic) =="
-# Scope to the session logs in the window — not the whole cache root, which may
-# hold unrelated trees (e.g. Copilot's bundled node_modules under ~/.cache).
+echo "KEYWORD HITS (heuristic, output text)"
 kw_out=$(rg -i --no-heading -c \
 	"error|failed|traceback|permission denied|exception|fatal" \
-	"${logs[@]}" 2>/dev/null | short | tail -20 || true)
-if [[ -n "$kw_out" ]]; then
-	printf '%s\n' "$kw_out"
-else
-	echo "  none"
-fi
-echo
-echo "Open a session_*.log for full STDOUT/STDERR. Header: ## [ts] status= cwd="
+	"${logs[@]}" 2>/dev/null | sed "s#$HOME#~#g" | tail -20 || true)
+[[ -n "$kw_out" ]] && printf '%s\n' "$kw_out" || echo "  none"

--- a/chezmoi/dot_local/bin/executable_log-thinking.sh
+++ b/chezmoi/dot_local/bin/executable_log-thinking.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# log-thinking.sh — capture agent reasoning/thinking to ~/.cache/<agent>/,
+# the analogue of log-bash.sh but sourced from the session event log rather
+# than a tool payload. NOT run by hand. Receives the hook payload as JSON on
+# stdin and is wired as:
+#   - Claude:  Stop + SubagentStop hooks (payload carries .transcript_path)
+#   - Copilot: postToolUse hook (payload carries .sessionId; reasoning lives in
+#              ~/.config/copilot/session-state/<id>/events.jsonl)
+#
+# Output: ~/.cache/<agent>/session_<id>.thinking.log, one appended block per
+# fire, deduped by a per-source line cursor under ~/.cache/<agent>/.thinking-cursor.
+#
+# SECURITY — thinking frequently reasons about secret VALUES the agent saw
+# (Kion creds, Jira/Confluence/gh tokens, age key). These logs live under
+# ~/.cache/<agent>, which the gdrive unison profile syncs. Defenses here:
+#   1. known secret values on disk are redacted literally before write;
+#   2. token-shaped strings are redacted by pattern (no length-only rule — that
+#      would clobber nix store hashes / git SHAs);
+#   3. files are created 0600;
+#   4. *.thinking.log and .thinking-cursor are excluded from the gdrive profile.
+# These reduce but do not eliminate leakage risk; treat the logs as sensitive.
+set -euo pipefail
+
+input=$(cat)
+command -v jq >/dev/null 2>&1 || exit 0
+
+agent_raw="${AGENT_NAME:-claude}"
+agent=$(printf '%s' "$agent_raw" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9._-')
+[[ -n "$agent" ]] || agent="claude"
+
+# Resolve source event log + session id + flavor from the payload shape.
+if printf '%s' "$input" | jq -e '.transcript_path' >/dev/null 2>&1; then
+	flavor=claude
+	src=$(printf '%s' "$input" | jq -r '.transcript_path // ""')
+	sid=$(printf '%s' "$input" | jq -r '.session_id // ""')
+elif printf '%s' "$input" | jq -e '.sessionId' >/dev/null 2>&1; then
+	flavor=copilot
+	sid=$(printf '%s' "$input" | jq -r '.sessionId // ""')
+	src="${COPILOT_HOME:-$HOME/.config/copilot}/session-state/$sid/events.jsonl"
+else
+	exit 0
+fi
+
+[[ -n "$src" && -f "$src" ]] || exit 0
+[[ -n "$sid" ]] || sid=$(basename "$src" .jsonl)
+
+log_dir="$HOME/.cache/$agent"
+state_dir="$log_dir/.thinking-cursor"
+mkdir -p "$log_dir" "$state_dir"
+logfile="$log_dir/session_${sid}.thinking.log"
+
+# Per-source line cursor: each hook fire processes only newly-appended lines.
+key=$(printf '%s' "$src" | cksum | cut -d' ' -f1)
+cursor_file="$state_dir/$key"
+cursor=0
+[[ -f "$cursor_file" ]] && cursor=$(cat "$cursor_file" 2>/dev/null || echo 0)
+[[ "$cursor" =~ ^[0-9]+$ ]] || cursor=0
+
+total=$(wc -l <"$src" 2>/dev/null | tr -d ' ')
+[[ "$total" =~ ^[0-9]+$ ]] || total=0
+((total < cursor)) && cursor=0 # transcript rotated/compacted -> restart
+((total > cursor)) || exit 0   # nothing new
+
+new_lines=$(tail -n +"$((cursor + 1))" "$src" 2>/dev/null || true)
+# Advance the cursor up front so empty/non-thinking turns are not reprocessed.
+printf '%s' "$total" >"$cursor_file"
+
+if [[ "$flavor" == claude ]]; then
+	blocks=$(printf '%s\n' "$new_lines" | jq -r '
+		select(.message.role == "assistant")
+		| .message.content[]?
+		| if .type == "thinking" then .thinking
+			elif .type == "redacted_thinking" then "[redacted_thinking block omitted]"
+			else empty end' 2>/dev/null || true)
+else
+	blocks=$(printf '%s\n' "$new_lines" | jq -r '
+		select(.type == "assistant.message")
+		| .data.reasoningText // empty
+		| select(. != "")' 2>/dev/null || true)
+fi
+
+[[ -n "$blocks" ]] || exit 0
+
+# Redact known secret values (literal) then token-shaped strings (pattern).
+redact() {
+	local text="$1" f v
+	for f in \
+		"$HOME/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID" \
+		"$HOME/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY" \
+		"$HOME/.cache/kion-aws-cache/AWS_SESSION_TOKEN" \
+		"$HOME/.config/ops-agent/jira-token" \
+		"$HOME/.config/confluence/token"; do
+		[[ -r "$f" ]] || continue
+		v=$(tr -d '\n\r' <"$f" 2>/dev/null || true)
+		[[ ${#v} -ge 8 ]] || continue
+		text="${text//"$v"/[REDACTED-SECRET]}"
+	done
+	printf '%s' "$text" | sed -E \
+		-e 's/(AKIA|ASIA)[0-9A-Z]{16}/[REDACTED-AWS-KEY]/g' \
+		-e 's/gh[posru]_[A-Za-z0-9]{20,}/[REDACTED-GH-TOKEN]/g' \
+		-e 's/github_pat_[A-Za-z0-9_]{20,}/[REDACTED-GH-TOKEN]/g' \
+		-e 's/AGE-SECRET-KEY-[0-9A-Z]+/[REDACTED-AGE-KEY]/g'
+}
+
+out=$(redact "$blocks")
+max_chars=20000
+if ((${#out} > max_chars)); then
+	out="${out:0:max_chars}"$'\n''... [thinking truncated; see transcript for full text]'
+fi
+
+umask 077
+{
+	printf '\n## [%s] %s reasoning (session %s)\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$agent" "$sid"
+	printf '%s\n' "$out"
+	printf -- '---\n'
+} >>"$logfile"
+chmod 600 "$logfile" 2>/dev/null || true

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -244,12 +244,23 @@ in {
       # (chezmoi/dot_local/bin/executable_log-bash.sh); only the Copilot hook
       # manifest is generated here. The Claude hook is injected into
       # settings.json by the ensureClaudeHook activation below.
+      # Wires both Copilot logging hooks. log-bash.sh logs the command+output;
+      # log-thinking.sh flushes new reasoning (data.reasoningText) from the
+      # session events.jsonl. postToolUse is the trigger for both — reasoning is
+      # written to events.jsonl before a tool completes, so per-tool-call capture
+      # catches it. (A turn with reasoning but no tool call is captured on the
+      # next tool call; switch to a stop/session-end event if Copilot adds one.)
       "copilot/hooks/log-bash.json".text = builtins.toJSON {
         version = 1;
         hooks.postToolUse = [
           {
             type = "command";
             bash = ''AGENT_NAME=copilot exec bash "$HOME/.local/bin/log-bash.sh"'';
+            timeoutSec = 10;
+          }
+          {
+            type = "command";
+            bash = ''AGENT_NAME=copilot bash "$HOME/.local/bin/log-thinking.sh"'';
             timeoutSec = 10;
           }
         ];
@@ -365,6 +376,18 @@ in {
             '.hooks.SessionEnd |= (. // []) + [{"hooks":[{"type":"command","command":"$HOME/.local/bin/claude-cache-stats","async":true}]}]' \
             "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
         fi
+        # Stop / SubagentStop: capture new reasoning from the transcript to
+        # ~/.cache/claude. Silent + async (zero model-token cost). Best-effort —
+        # Claude persists thinking text for most turns but stores signature-only
+        # for some (e.g. fast mode), which the script skips. See log-thinking.sh.
+        for _evt in Stop SubagentStop; do
+          if ! jq -e --arg e "$_evt" '.hooks[$e][]? | .hooks[]? | select(.command | test("log-thinking"))' "$_settings" > /dev/null 2>&1; then
+            _tmp=$(${pkgs.coreutils}/bin/mktemp)
+            jq --arg e "$_evt" \
+              '.hooks[$e] |= (. // []) + [{"hooks":[{"type":"command","command":"AGENT_NAME=claude bash \"$HOME/.local/bin/log-thinking.sh\"","async":true}]}]' \
+              "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
+          fi
+        done
         if ! jq -e '.attribution' "$_settings" > /dev/null 2>&1; then
           _tmp=$(${pkgs.coreutils}/bin/mktemp)
           jq '.attribution = {"commit": "", "pr": ""}' \

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -15,6 +15,10 @@
       htop
       tree
       base16-schemes # Required for Stylix theming
+      # GNU coreutils ahead of the BSD userland so shell scripts (cache-scan,
+      # log-bash.sh, etc.) can rely on GNU flags like `stat -c`. Linux/WSL have
+      # GNU coreutils natively; this makes darwin match.
+      coreutils
     ];
 
     # Ensure Homebrew is in PATH for all shells and applications


### PR DESCRIPTION
## Summary

Adds **`log-thinking.sh`**, the reasoning analogue of `log-bash.sh` — automatic capture of agent reasoning to `~/.cache/<agent>/session_<id>.thinking.log`, for both Claude and Copilot.

| Agent | Source | Trigger |
|-------|--------|---------|
| Claude | transcript `thinking` blocks | `Stop` + `SubagentStop` hooks |
| Copilot | `events.jsonl` `data.reasoningText` | `postToolUse` hook |

Deduped by a per-source line cursor; silent + async (zero model-token cost — fires after the assistant turn).

## Honest functionality note
- **Copilot** reasoning is reliably present and captured (verified: 160 lines from a real session).
- **Claude is best-effort**: thinking text is persisted for ~**1038/1665** blocks across local transcripts, but some sessions store only the encrypted `signature` with empty `.thinking` (e.g. fast mode). Those are skipped — not an error. Verified capture against a transcript that has real thinking; verified graceful no-op against one that doesn't.

## Security (this is reasoning, so it matters more than command logs)
- Known secret **values** on disk (Kion creds, Jira/Confluence tokens) are redacted literally; token-shaped strings (AWS `AKIA…`, GitHub `ghp_…`, `AGE-SECRET-KEY-…`) by pattern. **No length-only rule** — that would clobber nix store hashes / git SHAs.
- Files are created `0600`.
- `*.thinking.log` and `.thinking-cursor` are **excluded from the gdrive unison profile** (the logs live under `.cache/<agent>`, which is synced).
- ⚠️ Flagged separately: Copilot already syncs its **raw** reasoning via `.config/copilot/session-state/*/events.jsonl` (not ignored by the profile). Happy to exclude that too if you want — left as-is for now since it may back session-resume.

## Verification
- `shellcheck` clean; both flavors exercised against real transcripts; dedup confirmed.
- `task fmt:check` ✅, `task lint:nix` ✅; `ensureClaudeHook` jq injection tested for validity + idempotency (preserves the existing `compress-old-cache` Stop hook).
- Live `settings.json` updated so Claude capture is active next session; a `home-switch` makes it reproducible and wires Copilot.

---

## Added in second commit — cache-scan token reduction + coreutils (queued follow-ups)

**`cache-scan` is now token-lean by default** (it's read by an agent): one line per session + the stderr/interrupted failures only. `-v|--verbose` gates the command timeline and keyword scan. Abbreviated session ids, time-only failure stamps. Default output dropped ~50% (e.g. 28 lines vs 57 for 19 sessions).

**Dropped the GNU/BSD `stat`-flavor detection** — `cache-scan` uses `stat -c` directly now that GNU coreutils is guaranteed: added `coreutils` to the darwin `environment.systemPackages` (it was only incidentally on PATH before; native on Linux/WSL).

**Docs:** README gains an "Agent activity logs & cache-scan" section; `agent-defaults` + the `ops-cache-scan` skill updated for the terse/`--verbose` split.

> Scope note: these were separate queued tasks, but the `agent-defaults`/mirror regeneration entangled them with this branch's reasoning-capture changes, so they're bundled here rather than risk fragile branch surgery.

Verified: `shellcheck` clean, `task fmt:check`/`lint:nix` pass, darwin config evals with `coreutils`, markdownlint 0 errors, both terse + verbose output exercised against real logs.
