### PR TITLE
feat(bin): mdp-local — preflight launcher for the local stack

### DIFF
--- a/chezmoi/dot_local/bin/executable_mdp-local
+++ b/chezmoi/dot_local/bin/executable_mdp-local
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# mdp-local — preflight-checked launcher for the mdp-application local stack.
+#
+# Wraps `./run local` with the environment setup and prevention checks that
+# the in-repo CLI assumes are already in place. Each misstep below has bitten a
+# cold start of the stack:
+#   - direnv not loaded  -> nvm/sdk/DOCKER_HOST/PROJECT unset, build uses wrong
+#                           node/java, docker talks to the wrong socket
+#   - Colima not started -> DOCKER_HOST points at a dead socket; the CLI's
+#                           checkIfDockerIsRunning() fails late
+#   - stale Kion creds    -> checkIfAuthenticated() / aws calls ExpiredToken
+#   - missing bun         -> CLI build (`bun build:cli`) fails
+#
+# Resolves node/java/DOCKER_HOST/PROJECT from the project's own .envrc via
+# direnv (single source of truth) rather than duplicating them here, then
+# verifies the results and hands off to `./run local "$@"` (passes through
+# flags like --clean / --overmind).
+#
+# Override the repo location with MDP_DIR; defaults to the standard checkout.
+set -euo pipefail
+
+MDP_DIR="${MDP_DIR:-$HOME/Development/cmcs/mdp-application}"
+
+# ---- output helpers (respect NO_COLOR) -------------------------------------
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+	c_g=$'\033[32m' c_y=$'\033[33m' c_r=$'\033[31m' c_b=$'\033[34m' c_0=$'\033[0m'
+else
+	c_g='' c_y='' c_r='' c_b='' c_0=''
+fi
+step() { printf '%s==>%s %s\n' "$c_b" "$c_0" "$*"; }
+ok() { printf '  %s✓%s %s\n' "$c_g" "$c_0" "$*"; }
+warn() { printf '  %s!%s %s\n' "$c_y" "$c_0" "$*" >&2; }
+die() {
+	printf '  %s✗%s %s\n' "$c_r" "$c_0" "$*" >&2
+	exit 1
+}
+
+# ---- 0. repo -----------------------------------------------------------------
+step "Repository"
+[[ -d "$MDP_DIR" ]] || die "MDP_DIR not found: $MDP_DIR (set MDP_DIR=/path/to/mdp-application)"
+cd "$MDP_DIR"
+[[ -x ./run ]] || die "no ./run launcher in $MDP_DIR — wrong directory?"
+ok "$MDP_DIR"
+
+# ---- 1. project env via direnv (.envrc: nvm use, sdk env, DOCKER_HOST, …) ---
+step "Project environment (.envrc)"
+if command -v direnv >/dev/null 2>&1; then
+	direnv allow . >/dev/null 2>&1 || true
+	# Load .envrc into this shell so node/java/DOCKER_HOST/PROJECT/PATH are set
+	# exactly as the project defines them. Tolerate non-zero on partial loads.
+	eval "$(direnv export bash 2>/dev/null)" || true
+	ok "direnv loaded .envrc"
+else
+	warn "direnv not installed — falling back to manual nvm/sdk setup"
+fi
+
+# ---- 2. node (nvm + .nvmrc) ---------------------------------------------------
+step "Node (.nvmrc)"
+want_node="$(tr -d '[:space:]' <.nvmrc 2>/dev/null || true)"
+if ! command -v node >/dev/null 2>&1 || { [[ -n "$want_node" ]] && [[ "v$(node -v 2>/dev/null | sed 's/^v//')" != "${want_node/v/v}" ]]; }; then
+	# shellcheck disable=SC1090,SC1091
+	[[ -s "$HOME/.nvm/nvm.sh" ]] && source "$HOME/.nvm/nvm.sh"
+	command -v nvm >/dev/null 2>&1 && nvm use >/dev/null 2>&1 || true
+fi
+command -v node >/dev/null 2>&1 || die "node unavailable — install/activate ${want_node:-the .nvmrc version} via nvm"
+ok "node $(node -v) (wanted ${want_node:-any})"
+
+# ---- 3. java (sdkman + .sdkmanrc) — best effort ------------------------------
+step "Java (.sdkmanrc)"
+if ! command -v java >/dev/null 2>&1 && [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]]; then
+	# shellcheck disable=SC1090,SC1091
+	source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env >/dev/null 2>&1 || true
+fi
+if command -v java >/dev/null 2>&1; then
+	ok "$(java -version 2>&1 | head -1 | tr -d '"')"
+else
+	warn "java not on PATH — sdkman (sdk env) may not have loaded; the Java containers build in Docker so this is usually non-fatal"
+fi
+
+# ---- 4. bun (builds the ./run CLI) -------------------------------------------
+step "bun"
+command -v bun >/dev/null 2>&1 || die "bun not found — required for 'bun build:cli'. Install bun (it's in the home-manager package set)."
+ok "$(bun --version)"
+
+# ---- 5. Colima + Docker daemon -----------------------------------------------
+step "Container runtime (Colima)"
+if command -v colima >/dev/null 2>&1; then
+	if ! colima status >/dev/null 2>&1; then
+		warn "Colima not running — starting it (this can take ~30s)…"
+		colima start || die "colima start failed"
+	fi
+	ok "Colima running"
+else
+	warn "colima not installed — relying on whatever DOCKER_HOST points at"
+fi
+command -v docker >/dev/null 2>&1 || die "docker CLI not found"
+if ! docker info >/dev/null 2>&1; then
+	die "Docker daemon unreachable (DOCKER_HOST=${DOCKER_HOST:-unset}). Is Colima up?"
+fi
+ok "Docker daemon reachable${DOCKER_HOST:+ ($DOCKER_HOST)}"
+
+# ---- 6. AWS credentials (Kion) -----------------------------------------------
+# ./run local calls checkIfAuthenticated() and `aws s3` for the db-export
+# dataset; load fresh creds from the Kion cache and verify before handing off.
+step "AWS credentials"
+: "${AWS_REGION:=${REGION_A:-us-east-1}}"
+export AWS_REGION AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-$AWS_REGION}"
+kion="$HOME/.cache/kion-aws-cache"
+if [[ -r "$kion/AWS_ACCESS_KEY_ID" ]]; then
+	AWS_ACCESS_KEY_ID="$(/bin/cat "$kion/AWS_ACCESS_KEY_ID")"
+	AWS_SECRET_ACCESS_KEY="$(/bin/cat "$kion/AWS_SECRET_ACCESS_KEY")"
+	AWS_SESSION_TOKEN="$(/bin/cat "$kion/AWS_SESSION_TOKEN")"
+	export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+fi
+if command -v aws >/dev/null 2>&1 && aws sts get-caller-identity >/dev/null 2>&1; then
+	acct="$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo '?')"
+	ok "authenticated (account $acct, region $AWS_REGION)"
+else
+	die "AWS creds missing/expired. Refresh in your zsh shell, then re-run:
+       source ~/.local/bin/kac ensure   # or: gkion
+     (kac is zsh-only and must be sourced, so this bash launcher can't refresh for you.)"
+fi
+
+# ---- launch ------------------------------------------------------------------
+step "Launching: ./run local $*"
+exec ./run local "$@"

--- a/chezmoi/dot_local/bin/executable_mdp-status
+++ b/chezmoi/dot_local/bin/executable_mdp-status
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# mdp-status — readiness/health check for the mdp-application local stack.
+#
+# Companion to mdp-local. Reports whether the stack is actually serving, based
+# on container health + HTTP probes of the app/SAM ports — NOT on container age
+# (the local stack reuses already-healthy containers, so "recently recreated"
+# is the wrong signal).
+#
+#   mdp-status              one-shot: print status, exit 0 if ready
+#   mdp-status --wait       poll until ready (or --timeout), then exit
+#   mdp-status --timeout N  cap the wait at N seconds (default 600)
+#
+# Exit 0 = ready, 1 = not ready / timed out.
+set -uo pipefail
+
+wait=0
+timeout=600
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--wait) wait=1 ;;
+	--timeout)
+		shift
+		timeout="${1:-600}"
+		;;
+	--timeout=*) timeout="${1#*=}" ;;
+	-h | --help)
+		grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*) printf 'unknown arg: %s\n' "$1" >&2 && exit 2 ;;
+	esac
+	shift
+done
+[[ "$timeout" =~ ^[0-9]+$ ]] || timeout=600
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+	c_g=$'\033[32m' c_y=$'\033[33m' c_r=$'\033[31m' c_0=$'\033[0m'
+else
+	c_g='' c_y='' c_r='' c_0=''
+fi
+mark() { # $1=ok|warn|bad  $2=text
+	case "$1" in
+	ok) printf '  %s✓%s %s\n' "$c_g" "$c_0" "$2" ;;
+	warn) printf '  %s!%s %s\n' "$c_y" "$c_0" "$2" ;;
+	bad) printf '  %s✗%s %s\n' "$c_r" "$c_0" "$2" ;;
+	esac
+}
+
+container_running() { [[ "$(docker inspect -f '{{.State.Running}}' "$1" 2>/dev/null)" == "true" ]]; }
+container_healthy() { # healthy, or running with no healthcheck defined
+	local h
+	h="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$1" 2>/dev/null)" || return 1
+	[[ "$h" == "healthy" || "$h" == "none" ]] && container_running "$1"
+}
+http_alive() { # any HTTP status (incl 404/502) = process is serving; 000 = no
+	local code
+	code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 4 "$1" 2>/dev/null)"
+	[[ -n "$code" && "$code" != "000" ]]
+}
+port_open() { # bash /dev/tcp fallback for non-HTTP listeners
+	(exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && exec 3>&- 3<&-
+}
+
+check() {
+	local ready=0 detail=()
+	# DB layer (healthchecked)
+	if container_healthy db; then detail+=("ok|db container healthy"); else
+		detail+=("bad|db container not healthy")
+		ready=1
+	fi
+	# App containers
+	for c in data web; do
+		if container_running "$c"; then detail+=("ok|$c container running"); else
+			detail+=("bad|$c container not running")
+			ready=1
+		fi
+	done
+	# App HTTP (web 8080, data 8081 respond — 404 at / is normal/alive)
+	if http_alive http://127.0.0.1:8080/; then detail+=("ok|web app responding (:8080)"); else
+		detail+=("bad|web app not responding (:8080)")
+		ready=1
+	fi
+	if http_alive http://127.0.0.1:8081/; then detail+=("ok|data app responding (:8081)"); else
+		detail+=("bad|data app not responding (:8081)")
+		ready=1
+	fi
+	# SAM local (API gateway listens immediately; lambdas are LAZY-warm)
+	if port_open 3000; then detail+=("ok|SAM local API listening (:3000)"); else
+		detail+=("warn|SAM local API not listening (:3000) — may still be starting")
+	fi
+	printf '%s\n' "${detail[@]}"
+	return $ready
+}
+
+render() {
+	while IFS='|' read -r kind text; do mark "$kind" "$text"; done
+}
+
+if [[ "$wait" -eq 1 ]]; then
+	deadline=$(($(date +%s) + timeout))
+	while :; do
+		out="$(check)"
+		rc=$?
+		if [[ $rc -eq 0 ]]; then
+			printf '%s\n' "$out" | render
+			mark ok "stack READY"
+			exit 0
+		fi
+		if (($(date +%s) >= deadline)); then
+			printf '%s\n' "$out" | render
+			mark bad "stack NOT ready after ${timeout}s"
+			exit 1
+		fi
+		sleep 10
+	done
+else
+	out="$(check)"
+	rc=$?
+	printf '%s\n' "$out" | render
+	if [[ $rc -eq 0 ]]; then mark ok "stack READY"; else mark bad "stack NOT ready"; fi
+	exit $rc
+fi


### PR DESCRIPTION
Adds `~/.local/bin/mdp-local`, a preflight-checked wrapper around the mdp-application `./run local`.

## Why

`./run local` already validates AWS auth, Docker, and buildx *from inside the CLI* — but it assumes the surrounding environment is already set up. The recurring cold-start missteps happen **before** that point:

| Misstep | Prevention in `mdp-local` |
|---|---|
| `.envrc` not loaded → wrong node/java, `DOCKER_HOST` unset | Loads the project's own `.envrc` via `direnv export` (single source of truth — no duplication) |
| Wrong Node | Verifies `node -v` against `.nvmrc` (v24.1.0); `nvm use` fallback |
| Colima not started → dead Docker socket | `colima start` if `colima status` is down, then confirms `docker info` |
| Stale Kion creds → `ExpiredTokenException` | Loads creds from the Kion cache and verifies with `aws sts get-caller-identity`; clear refresh instruction (`kac ensure` / `gkion`) since kac is zsh-only |
| Missing `bun` → `bun build:cli` fails | Hard-checks `bun` is present |

Then `exec ./run local "$@"` (passes through `--clean` / `--overmind`).

## Notes

- Manual helper → stays in `dot_local/bin/` (not `ai-tools/`). Deployed to `~/.local/bin/mdp-local`, on `$PATH`.
- Repo path overridable via `MDP_DIR` (defaults to `~/Development/cmcs/mdp-application`).
- `shellcheck` + `shfmt` clean; `bash -n` parses. Not exercised end-to-end (would boot the full stack), so the live run is unverified — the static checks and per-step diagnostics are.
- Independent of #51; based on `main`. Intentionally no doc edits to avoid cross-PR churn with #51's `agent-defaults.md`/README changes — a helper-list bullet can follow once #51 merges.