### PR TITLE
feat: codify agent token-cost levers (Copilot model=auto, instruction-size guard, MCP hygiene, reference doc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ agent consumes it. The scripts assume GNU coreutils (`stat -c`), guaranteed by
 about; reasoning logs redact known secrets, are written `0600`, and are excluded
 from the gdrive sync profile. Treat the cache logs as sensitive.
 
+**Token/credit cost:** for keeping Claude Code and Copilot CLI token usage down
+(and which levers are codified in this repo), see
+[docs/agent-token-cost-levers.md](docs/agent-token-cost-levers.md).
+
 ## AI Tooling (Skills + Agents)
 
 Custom skills and agents live in [`ai-tools/`](ai-tools/) as the single source of truth, modeled on the

--- a/docs/agent-token-cost-levers.md
+++ b/docs/agent-token-cost-levers.md
@@ -1,0 +1,50 @@
+# Agent token-cost levers
+
+Reference for keeping Claude Code and GitHub Copilot CLI token/credit usage
+down. Deliberately a standalone doc — **not** part of `agent-defaults.md`,
+because anything added there loads into every session's prompt and would cost
+tokens to save tokens.
+
+## Billing context
+
+- **Claude Code** — token-metered. The system prompt + tool defs +
+  instruction files (`CLAUDE.md`) form a cacheable prefix; a stable prefix hit
+  within the cache TTL bills at a fraction of the normal input rate.
+- **GitHub Copilot CLI** — usage-based billing (AI Credits) since June 1 2026.
+  Token-metered per model, with input / **cached input** / output priced
+  separately; cached input is heavily discounted (~10% of input). Code
+  completions / next-edit suggestions are not billed. So the same
+  stable-prefix discipline that helps Claude now also lowers the Copilot bill.
+
+## Levers codified in this repo
+
+| Lever | Mechanism | Status |
+|---|---|---|
+| Stable, single-source instruction files | `agent-defaults.md` → generated copies; `generate`/`check:agent-instructions`/`check:copilot-instructions` gates prevent drift, keeping the cached prefix stable | active |
+| Instruction-size budget | `task check:instruction-size` (in the `lint:nix` pre-commit chain) fails if `agent-defaults.md` exceeds the line/byte budget | active |
+| Lean skill set | fewer skills = smaller skill listing (Claude) / fewer bridged prompt files (Copilot); `cleanupOrphanedSkills` removes deployed orphans | active |
+| Copilot default model | `ensureCopilotSettings` sets `model: "auto"` in `~/.config/copilot/settings.json` | active |
+| Lean Copilot MCP set | managed `copilot/mcp-config.json` (empty by default); servers added deliberately in `common.nix`, not accumulated via `/mcp add` | active |
+
+## Levers that are not codifiable here
+
+- **GitHub budgets, spend-blocking, model policies** — account/org dashboard,
+  not nix-managed.
+- **Session discipline** — reuse a session and avoid churning the prompt prefix
+  mid-session so the cache discount keeps applying; pick a cheaper model for
+  simple tasks. Operational, not config.
+
+## Visibility
+
+- **Claude:** `claude-cache-stats` (SessionEnd hook) reports prompt-cache hit
+  rate from transcripts.
+- **Copilot:** no equivalent — `events.jsonl` exposes no token/cache counts;
+  usage is visible only in the GitHub billing dashboard.
+
+## Notes
+
+- `auto` routes Copilot to a capability-appropriate model, optimizing for fit,
+  not strictly lowest cost. For hard cost-minimization, pin a cheap model
+  instead (also settable in `ensureCopilotSettings`).
+- The managed `copilot/mcp-config.json` is read-only (a nix-store symlink), so
+  add MCP servers by editing `common.nix`, not with interactive `/mcp add`.

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -412,6 +412,25 @@ in {
         fi
       '';
 
+      # Copilot CLI default model = "auto": let Copilot route each request to a
+      # capability-appropriate model. Under GitHub's usage-based billing (from
+      # June 2026) the CLI is token-metered, so the model choice is the primary
+      # cost lever. Merged (not overwritten) so Copilot can still persist its
+      # other settings; self-healing — reconciles whenever the value drifts.
+      # COPILOT_HOME (zsh.nix) points the config dir at ~/.config/copilot.
+      ensureCopilotSettings = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        _settings="${xdgConfigHome}/copilot/settings.json"
+        if [ ! -f "$_settings" ]; then
+          ${pkgs.coreutils}/bin/mkdir -p "${xdgConfigHome}/copilot"
+          ${pkgs.coreutils}/bin/printf '%s\n' '{}' > "$_settings"
+        fi
+        if [ "$(jq -r '.model // empty' "$_settings")" != "auto" ]; then
+          _tmp=$(${pkgs.coreutils}/bin/mktemp)
+          jq '.model = "auto"' \
+            "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
+        fi
+      '';
+
       # Register Claude Code marketplaces in ~/.config/claude/settings.json:
       #
       #   nix-config-dev          (local)  — this repo's ai-tools/ directory.

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -266,6 +266,18 @@ in {
         ];
       };
 
+      # Copilot CLI MCP servers, managed declaratively so the set stays lean.
+      # Every enabled MCP server injects its tool definitions into context on
+      # each agent step — input tokens on every turn under Copilot's
+      # usage-based billing. Empty is the leanest default; add a server here
+      # only when it's actually needed (e.g. an `aws-api` entry mirroring
+      # chezmoi/dot_claude/settings.json, pointing at
+      # ~/.local/bin/ai-tools/aws-mcp-server) rather than accumulating
+      # always-on servers via interactive `/mcp add`.
+      "copilot/mcp-config.json".text = builtins.toJSON {
+        mcpServers = {};
+      };
+
       # Single source of truth for custom agent/skill definitions is the
       # top-level ai-tools/ directory (modeled on the obra/superpowers layout).
       # Deploy those definitions into both Claude's and Copilot's XDG config

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -374,6 +374,7 @@ tasks:
       deadnix .
       task check:copilot-instructions
       task check:agent-instructions
+      task check:instruction-size
 
   lint:md:
     desc: Lint markdown files (skips ai-tools/ and chezmoi-generated agent instructions)
@@ -412,6 +413,30 @@ tasks:
   check:copilot-instructions:
     desc: Verify duplicated Copilot instruction files stay in sync
     cmd: bash ./scripts/check-copilot-instructions-sync.sh
+
+  check:instruction-size:
+    desc: Guard the per-turn agent instruction source against token bloat
+    platforms: [linux, darwin]
+    cmd: |
+      src="chezmoi/dot_config/instructions/agent-defaults.md"
+      max_lines=280
+      max_bytes=16000
+      lines=$(wc -l <"$src" | tr -d ' ')
+      bytes=$(wc -c <"$src" | tr -d ' ')
+      fail=0
+      if [ "$lines" -gt "$max_lines" ]; then
+        printf 'agent-defaults.md: %s lines exceeds budget %s\n' "$lines" "$max_lines" >&2
+        fail=1
+      fi
+      if [ "$bytes" -gt "$max_bytes" ]; then
+        printf 'agent-defaults.md: %s bytes exceeds budget %s\n' "$bytes" "$max_bytes" >&2
+        fail=1
+      fi
+      if [ "$fail" -ne 0 ]; then
+        printf '%s\n' "This file is rendered into every agent session's system prompt (the cached prefix); growth raises the per-turn token cost on every Claude AND Copilot session. Trim it, or raise the budget deliberately in taskfile.yaml." >&2
+        exit 1
+      fi
+      printf 'instruction size OK: %s lines / %s bytes (budget %s / %s)\n' "$lines" "$bytes" "$max_lines" "$max_bytes"
 
   generate:agent-instructions:
     desc: Render agent-defaults.md into chezmoi-managed files for Windows deployment


### PR DESCRIPTION
Codifies the Copilot CLI default model as `auto` via a new `ensureCopilotSettings` home-manager activation (mirrors `ensureClaudeHook`): jq-merges `model: "auto"` into `~/.config/copilot/settings.json` (COPILOT_HOME), non-destructive and self-healing on drift.

**Why:** GitHub Copilot moved to usage-based billing (AI Credits, token-metered) on June 1 2026, so model choice is now the primary cost lever for the CLI. `auto` routes each request to a capability-appropriate model.

Verified: `statix`/`deadnix` clean; `nix eval` of the rendered activation confirms it targets `~/.config/copilot/settings.json` and sets `.model = "auto"`. Already applied live this session.

Independent of #51/#52/#53; based on `main` (touches the activation block of common.nix — disjoint from #51's edits).