### PR TITLE
feat(bootstrap): upgrade to nixos-26.05 and harden Debian WSL bootstrap

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,14 +1,28 @@
+_local_bin="$HOME/.local/bin"
+mkdir -p "$_local_bin"
+PATH_add "$_local_bin"
+
 # Use the Nix flake devShell (default) when Nix is available.
 if command -v nix > /dev/null 2>&1; then
   use flake
 else
-  # Nix not available: bootstrap go-task into ~/.local so the install script works.
-  _local_bin="$HOME/.local/bin"
-  mkdir -p "$_local_bin"
-  PATH_add "$_local_bin"
-
-  if ! command -v task > /dev/null 2>&1 && ! [[ -x "$_local_bin/task" ]]; then
-    log_status "go-task not found; installing to $_local_bin"
-    sh -c "$(curl -fsSL https://taskfile.dev/install.sh)" -- -d -b "$_local_bin"
+  # Nix not available: ensure baseline tools via apt (Debian/Ubuntu WSL).
+  if command -v apt-get > /dev/null 2>&1; then
+    _missing=()
+    command -v git  > /dev/null 2>&1 || _missing+=(git)
+    command -v curl > /dev/null 2>&1 || _missing+=(curl)
+    if [[ ${#_missing[@]} -gt 0 ]]; then
+      log_status "installing missing tools via apt: ${_missing[*]}"
+      sudo apt-get update -qq
+      sudo apt-get install -y "${_missing[@]}"
+    fi
   fi
+fi
+
+# Ensure go-task is available regardless of whether Nix loaded the devShell.
+# Covers: no Nix, Nix present but use flake failed, or fresh bootstrap before
+# the flake devShell is activated for the first time.
+if ! command -v task > /dev/null 2>&1 && ! [[ -x "$_local_bin/task" ]]; then
+  log_status "go-task not in PATH; installing to $_local_bin"
+  sh -c "$(curl -fsSL https://taskfile.dev/install.sh)" -- -d -b "$_local_bin"
 fi

--- a/chezmoi/run_install-go-tools.sh.tmpl
+++ b/chezmoi/run_install-go-tools.sh.tmpl
@@ -11,10 +11,22 @@ exit 0
 
 set -euo pipefail
 
-command -v go >/dev/null 2>&1 || {
-  printf 'install-go-tools: go is required but not on PATH\n' >&2
-  exit 1
-}
+# Augment PATH with common go/nix locations in case the profile isn't sourced yet.
+for _gobin in \
+  "$HOME/.nix-profile/bin" \
+  "/nix/var/nix/profiles/default/bin" \
+  "/usr/local/go/bin" \
+  "$HOME/go/bin"; do
+  if [[ -x "$_gobin/go" ]]; then
+    export PATH="$_gobin:$PATH"
+    break
+  fi
+done
+
+if ! command -v go >/dev/null 2>&1; then
+  printf 'install-go-tools: go not on PATH — skipping (run chezmoi apply again after home-manager activates)\n' >&2
+  exit 0
+fi
 
 src_root="${HOME}/.local/src"
 bin_dir="${HOME}/.local/bin"

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     "base16-helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1760703920,
-        "narHash": "sha256-m82fGUYns4uHd+ZTdoLX2vlHikzwzdu2s2rYM2bNwzw=",
+        "lastModified": 1776754714,
+        "narHash": "sha256-E3OAK27smtATTmX45uoTSRsVD+Y+ZiVVfgM/tjpbtYg=",
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "rev": "d646af9b7d14bff08824538164af99d0c521b185",
+        "rev": "4d508123037e7851ad36ebf7d9c48b0e9e1eb581",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1764873433,
-        "narHash": "sha256-1XPewtGMi+9wN9Ispoluxunw/RwozuTRVuuQOmxzt+A=",
+        "lastModified": 1779670703,
+        "narHash": "sha256-UdfMivNMwCCqQsYDg5pSz8X2IOaOrIZLIIy+Bg3CO2o=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "f7ffd917ac0d253dbd6a3bf3da06888f57c69f92",
+        "rev": "942159e73e40bf785816f7f1f5feed9ef3d7c8f9",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -140,20 +140,18 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "host": "gitlab.gnome.org",
         "lastModified": 1767737596,
         "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
         "owner": "GNOME",
         "repo": "gnome-shell",
         "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-        "type": "gitlab"
+        "type": "github"
       },
       "original": {
-        "host": "gitlab.gnome.org",
         "owner": "GNOME",
-        "ref": "gnome-49",
         "repo": "gnome-shell",
-        "type": "gitlab"
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
+        "type": "github"
       }
     },
     "home-manager": {
@@ -163,16 +161,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1780361225,
+        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -184,16 +182,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1772129556,
-        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "lastModified": 1780789116,
+        "narHash": "sha256-+/LcDMJGYQVLp3ECZ1jBhj3GcQU+Yt+OTsDsQFz8cMs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "rev": "731951a251ca96cbd12a8e1bde63737e21947644",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
-        "ref": "nix-darwin-25.11",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -206,11 +204,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780169171,
-        "narHash": "sha256-3HBYDfBgZ+ph52HS6Ks/bMMwuh2uONIT72sZ1CtLE/s=",
+        "lastModified": 1780765279,
+        "narHash": "sha256-md6QHmlIx40bQkun43M2eT8aav5GURGkXEMFwof6uZs=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "998b2821c30b2938637230916904ceb8757c79e8",
+        "rev": "3e6d8af994e2a2d31af7a91863d7c0d6e278d951",
         "type": "github"
       },
       "original": {
@@ -222,16 +220,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1780734595,
+        "narHash": "sha256-DmTfP92QFYRLOGXlMIE54MAgxSJjDWocl3gRNOu72Os=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "9b696460ac78b5ccfc17c854d8c976f20456e943",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -248,11 +246,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767886815,
-        "narHash": "sha256-pB2BBv6X9cVGydEV/9Y8+uGCvuYJAlsprs1v1QHjccA=",
+        "lastModified": 1779766384,
+        "narHash": "sha256-P7Ohnlq8b8b2fU+Sgkrej7LBTM60LBTkHleLuYzmLmU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ff84374d77ff62e2e13a46c33bfeb73590f9fef",
+        "rev": "57800b7ab648725ccd33551d01484ee14952ad3f",
         "type": "github"
       },
       "original": {
@@ -302,11 +300,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
         "type": "github"
       },
       "original": {
@@ -329,23 +327,22 @@
         ],
         "nur": "nur",
         "systems": "systems",
-        "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1778680496,
-        "narHash": "sha256-tUq1WASV0dHLv3j18log8V6Esq0NYkXuzNH2EHsstcg=",
+        "lastModified": 1780702455,
+        "narHash": "sha256-+srjPGNy67nKytYwdlepycL51IG6S34sS4MKRZXK8G0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fc5bec2e44678eeaa221d566d447a0257a884737",
+        "rev": "54fa19702f4f2c7f6a981a92850678933588af9a",
         "type": "github"
       },
       "original": {
         "owner": "danth",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "stylix",
         "type": "github"
       }
@@ -362,23 +359,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "tinted-foot": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726913040,
-        "narHash": "sha256-+eDZPkw7efMNUf3/Pv0EmsidqdwNJ1TaOum6k7lngDQ=",
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
         "type": "github"
       }
     },
@@ -401,11 +381,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1767817087,
-        "narHash": "sha256-eGE8OYoK6HzhJt/7bOiNV2cx01IdIrHL7gXgjkHRdNo=",
+        "lastModified": 1777806186,
+        "narHash": "sha256-PDF0/wObw4nIsSBeXVYLsloXOiphXCgIdsrNcVXguKs=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "bd99656235aab343e3d597bf196df9bc67429507",
+        "rev": "0c94645546f4f3ddac77a1a5fce54eb95bf50795",
         "type": "github"
       },
       "original": {
@@ -417,11 +397,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1767489635,
-        "narHash": "sha256-e6nnFnWXKBCJjCv4QG4bbcouJ6y3yeT70V9MofL32lU=",
+        "lastModified": 1778379944,
+        "narHash": "sha256-wPDFzMGSlARlw0Sfsn48Q2+jPSfk6N0Ng6BC/d+7Q24=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "3c32729ccae99be44fe8a125d20be06f8d7d8184",
+        "rev": "fe0203a198690e71a5ff11e08812a4673de3678d",
         "type": "github"
       },
       "original": {
@@ -433,11 +413,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1767488740,
-        "narHash": "sha256-wVOj0qyil8m+ouSsVZcNjl5ZR+1GdOOAooAatQXHbuU=",
+        "lastModified": 1778378178,
+        "narHash": "sha256-OXPXRIQgGwV77HjYRryOHguh4ALX96jkg+tseLkGgHA=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "11abb0b282ad3786a2aae088d3a01c60916f2e40",
+        "rev": "9cd816033ff969415b190722cddf134e78a5665f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,29 @@
 {
   description = "NixOS configuration";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCUSeBs="
+    ];
+  };
+
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     nixos-wsl = {
       url = "github:nix-community/NixOS-WSL/main";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # nix-darwin for macOS system management
     nix-darwin = {
-      url = "github:LnL7/nix-darwin/nix-darwin-25.11";
+      url = "github:LnL7/nix-darwin/nix-darwin-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # home-manager, used for managing user configuration
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       # The `follows` keyword in inputs is used for inheritance.
       # Here, `inputs.nixpkgs` of home-manager is kept consistent with
       # the `inputs.nixpkgs` of the current flake,
@@ -27,7 +36,7 @@
       inputs.home-manager.follows = "home-manager";
     };
     stylix = {
-      url = "github:danth/stylix/release-25.11";
+      url = "github:danth/stylix/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     sops-nix = {
@@ -54,31 +63,31 @@
         libGL
         libxkbcommon
         wayland
-        xorg.libX11
-        xorg.libXcursor
-        xorg.libXext
-        xorg.libXrender
-        xorg.libXfixes
-        xorg.libXi
-        xorg.libXinerama
-        xorg.libXrandr
-        xorg.libXxf86vm
+        libx11
+        libxcursor
+        libxext
+        libxrender
+        libxfixes
+        libxi
+        libxinerama
+        libxrandr
+        libxxf86vm
       ];
     goGuiDevPackagesFor = pkgs:
       with pkgs; [
         libGL.dev
         libxkbcommon.dev
         wayland.dev
-        xorg.xorgproto
-        xorg.libX11.dev
-        xorg.libXcursor.dev
-        xorg.libXext.dev
-        xorg.libXrender.dev
-        xorg.libXfixes.dev
-        xorg.libXi.dev
-        xorg.libXinerama.dev
-        xorg.libXrandr.dev
-        xorg.libXxf86vm.dev
+        xorgproto
+        libx11.dev
+        libxcursor.dev
+        libxext.dev
+        libxrender.dev
+        libxfixes.dev
+        libxi.dev
+        libxinerama.dev
+        libxrandr.dev
+        libxxf86vm.dev
       ];
     goGuiPkgConfigPathFor = pkgs: let
       goGuiDevPackages = goGuiDevPackagesFor pkgs;

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -41,28 +41,6 @@
     dontCheckRuntimeDeps = true;
     pythonRelaxDeps = (old.pythonRelaxDeps or []) ++ ["click"];
   });
-  python3Patched =
-    pkgs.python3
-    // {
-      override = args:
-        pkgs.python3.override (args
-          // {
-            packageOverrides =
-              lib.composeExtensions
-              (args.packageOverrides or (_: _: {}))
-              (_: prev: {
-                imageio-ffmpeg = prev.imageio-ffmpeg.overridePythonAttrs (_: {
-                  doCheck = false;
-                });
-                imageio = prev.imageio.overridePythonAttrs (_: {
-                  doCheck = false;
-                });
-              });
-          });
-    };
-  checkovPatched = pkgs.callPackage (pkgs.path + "/pkgs/by-name/ch/checkov/package.nix") {
-    python3 = python3Patched;
-  };
   direnvPatched =
     if pkgs.stdenv.isDarwin
     then
@@ -71,6 +49,11 @@
         doCheck = false;
       })
     else pkgs.direnv;
+  # pipx 1.8.0 has test failures in nixos-26.05 due to PEP 508 spacing
+  # differences in the packaging library — skip tests, the package itself works.
+  pipxPatched = pkgs.pipx.overridePythonAttrs (_old: {
+    doCheck = false;
+  });
   commonPackages = with pkgs; [
     # Version control
     git
@@ -97,7 +80,7 @@
 
     # Python
     python3
-    pipx
+    pipxPatched
     uv
 
     # JavaScript
@@ -107,10 +90,10 @@
     awscli2
     awslogs
     awsSamCliPatched
-    checkovPatched
+    checkov
 
     # Containers & process management
-    docker
+    docker_29
     docker-buildx
     docker-compose
     overmind
@@ -589,13 +572,27 @@ in {
           fi
         fi
       '';
+
+      setDefaultShell = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        _zsh="${homeDirectory}/.nix-profile/bin/zsh"
+        _username="${config.home.username}"
+        if [ -x "$_zsh" ]; then
+          if ! ${pkgs.gnugrep}/bin/grep -qxF "$_zsh" /etc/shells 2>/dev/null; then
+            ${pkgs.coreutils}/bin/printf '%s\n' "$_zsh" | sudo -n tee -a /etc/shells >/dev/null 2>&1 || true
+          fi
+          # -n: non-interactive; silently skipped if sudo requires a password.
+          # The taskfile's home-switch/upgrade tasks run the same command
+          # interactively as a fallback.
+          sudo -n /usr/sbin/usermod -s "$_zsh" "$_username" 2>/dev/null || true
+        fi
+      '';
     };
 
     # Common packages shared across Linux, WSL, and macOS.
     packages = lib.filter availableOnHost commonPackages;
 
     # Common home-manager settings
-    stateVersion = "25.05";
+    stateVersion = "26.05";
 
     # Make Copilot defaults visible to desktop, remote, and shared IDE sessions.
     # Source paths come from copilotInstructionPaths in the let-block above so
@@ -825,6 +822,7 @@ in {
     # Direnv for automatic environment loading
     direnv = {
       enable = true;
+      enableBashIntegration = true;
       enableZshIntegration = true;
       package = direnvPatched;
     };

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -800,6 +800,8 @@ in {
         };
         merge.conflictStyle = "zdiff3";
         diff.colorMoved = "default";
+        credential."https://github.com".helper = "!/usr/bin/env gh auth git-credential";
+        credential."https://gist.github.com".helper = "!/usr/bin/env gh auth git-credential";
       };
     };
 

--- a/home-manager/home-wsl.nix
+++ b/home-manager/home-wsl.nix
@@ -33,30 +33,30 @@
     libGL
     libxkbcommon
     wayland
-    xorg.libX11
-    xorg.libXcursor
-    xorg.libXext
-    xorg.libXrender
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXinerama
-    xorg.libXrandr
-    xorg.libXxf86vm
+    libx11
+    libxcursor
+    libxext
+    libxrender
+    libxfixes
+    libxi
+    libxinerama
+    libxrandr
+    libxxf86vm
   ];
   guiDevPackages = with pkgs; [
     libGL.dev
     libxkbcommon.dev
     wayland.dev
-    xorg.xorgproto
-    xorg.libX11.dev
-    xorg.libXcursor.dev
-    xorg.libXext.dev
-    xorg.libXrender.dev
-    xorg.libXfixes.dev
-    xorg.libXi.dev
-    xorg.libXinerama.dev
-    xorg.libXrandr.dev
-    xorg.libXxf86vm.dev
+    xorgproto
+    libx11.dev
+    libxcursor.dev
+    libxext.dev
+    libxrender.dev
+    libxfixes.dev
+    libxi.dev
+    libxinerama.dev
+    libxrandr.dev
+    libxxf86vm.dev
   ];
   guiPkgConfigPath =
     (lib.makeSearchPath "lib/pkgconfig" guiDevPackages)

--- a/home-manager/modules/sops.nix
+++ b/home-manager/modules/sops.nix
@@ -1,14 +1,22 @@
 # Home-manager sops-nix configuration
 # Decrypts user-level secrets at home-manager activation time using an age key.
 # Generate a key with: age-keygen -o ~/.config/sops/age/keys.txt
+#
+# The entire sops block is guarded by builtins.pathExists so that an initial
+# install (where the age key has not yet been provisioned) can complete
+# home-manager switch without errors.  After provision-secrets.sh writes the
+# key, the next switch will find the key present and decrypt all secrets.
 {
   config,
   pkgs,
   lib,
   ...
-}: {
-  sops = {
-    age.keyFile = "${config.home.homeDirectory}/.config/sops/age/keys.txt";
+}: let
+  ageKeyFile = "${config.home.homeDirectory}/.config/sops/age/keys.txt";
+  ageKeyPresent = builtins.pathExists ageKeyFile;
+in {
+  sops = lib.mkIf ageKeyPresent {
+    age.keyFile = ageKeyFile;
     defaultSopsFormat = "yaml";
 
     secrets = {

--- a/hosts/wsl/default.nix
+++ b/hosts/wsl/default.nix
@@ -26,5 +26,5 @@
     zsh
   ];
 
-  system.stateVersion = "25.11";
+  system.stateVersion = "26.05";
 }

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,8 @@ for _pkg in "${_conflicting_packages[@]}"; do
 done
 
 echo "==> Applying configuration via go-task..."
+echo "    (sops secrets are skipped on first switch — they are unlocked after"
+echo "     the age key is provisioned in step 7 and re-applied in step 8)"
 cd "$SCRIPT_DIR"
 
 nix shell nixpkgs#go-task nixpkgs#chezmoi --command bash -euo pipefail -c '

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,31 @@ else
 	echo "==> Nix already installed ($(nix --version))"
 fi
 
+# ── 1b. Trust this user and wire the nix-community binary cache ───────────────
+# nixConfig in flake.nix sets extra-substituters only when the calling user is
+# trusted. For non-NixOS (Determinate Systems installer), write the settings
+# directly to /etc/nix/nix.conf so every subsequent nix invocation picks them up
+# without interactive prompts.
+# The Determinate Systems installer owns /etc/nix/nix.conf and will overwrite it
+# on upgrades. User settings go in nix.custom.conf (included via !include).
+_nix_custom_conf=/etc/nix/nix.custom.conf
+if [[ -d /etc/nix ]]; then
+	[[ -f "$_nix_custom_conf" ]] || sudo touch "$_nix_custom_conf"
+	if ! grep -qE '^\s*trusted-users\s*=' "$_nix_custom_conf"; then
+		echo "==> Adding $USER to nix trusted-users in $_nix_custom_conf..."
+		printf 'trusted-users = root %s\n' "$USER" | sudo tee -a "$_nix_custom_conf" >/dev/null
+	fi
+	if ! grep -q 'nix-community.cachix.org' "$_nix_custom_conf"; then
+		echo "==> Registering nix-community binary cache in $_nix_custom_conf..."
+		printf 'extra-trusted-substituters = https://nix-community.cachix.org\n' | sudo tee -a "$_nix_custom_conf" >/dev/null
+		printf 'extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCUSeBs=\n' | sudo tee -a "$_nix_custom_conf" >/dev/null
+	fi
+	# Restart the daemon so the new settings take effect before the build steps.
+	if command -v systemctl >/dev/null 2>&1; then
+		sudo systemctl restart nix-daemon.service 2>/dev/null || true
+	fi
+fi
+
 # ── 2. Bootstrap configuration via go-task ────────────────────────────────────
 # Remove any standalone profile entries that conflict with home-manager — home-manager
 # owns these packages and will fail activation if duplicates exist in the nix profile.
@@ -126,7 +151,7 @@ fi
 # the flake inputs to current and re-switches so the freshly-installed shell is
 # already on the latest before the user's first interactive session.
 echo "==> Upgrading flake inputs and re-switching (task upgrade)..."
-nix shell nixpkgs#go-task --command bash -c '
+nix shell nixpkgs#go-task nixpkgs#chezmoi --command bash -c '
   cd "'"$SCRIPT_DIR"'"
   task upgrade
 '

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -6,6 +6,12 @@ vars:
   IS_LINUX: '{{eq OS "linux"}}'
   IS_DARWIN: '{{eq OS "darwin"}}'
 
+  # Resolve chezmoi from PATH or fall back to a temporary nix shell. This
+  # covers the bootstrap window where home-manager has not yet activated the
+  # nix profile (and therefore chezmoi is not yet on PATH).
+  CHEZMOI:
+    sh: command -v chezmoi 2>/dev/null || printf 'nix shell nixpkgs#chezmoi --command chezmoi'
+
   # Auto-detect host based on hostname or allow override.
   # The generic names in this repo are placeholder install targets for new systems.
   DETECTED_HOST:
@@ -123,37 +129,37 @@ tasks:
         platforms: [linux, darwin]
       - |
         _src=$(printf '%s/chezmoi' "$PWD" | tr '\\' '/')
-        chezmoi init --source "$_src"
+        {{.CHEZMOI}} init --source "$_src"
 
   chezmoi-apply:
     desc: Apply chezmoi dotfiles to the home directory
-    cmd: chezmoi apply
+    cmd: '{{.CHEZMOI}} apply'
 
   _chezmoi-ensure:
     internal: true
     desc: Initialize chezmoi if needed, then apply
     cmd: |
       _src=$(printf '%s/chezmoi' "$PWD" | tr '\\' '/')
-      chezmoi init --source "$_src"
-      chezmoi apply --force
+      {{.CHEZMOI}} init --source "$_src"
+      {{.CHEZMOI}} apply --force
 
   chezmoi-diff:
     desc: Show pending chezmoi changes without applying them
-    cmd: chezmoi diff
+    cmd: '{{.CHEZMOI}} diff'
 
   chezmoi-status:
     desc: Show chezmoi managed file status
-    cmd: chezmoi status
+    cmd: '{{.CHEZMOI}} status'
 
   chezmoi-add:
     desc: Add a file to the chezmoi source (FILE=<path>)
-    cmd: chezmoi add "{{.FILE}}"
+    cmd: '{{.CHEZMOI}} add "{{.FILE}}"'
     requires:
       vars: [FILE]
 
   chezmoi-edit:
     desc: Edit a chezmoi-managed file (FILE=<path>)
-    cmd: chezmoi edit "{{.FILE}}"
+    cmd: '{{.CHEZMOI}} edit "{{.FILE}}"'
     requires:
       vars: [FILE]
 
@@ -277,6 +283,11 @@ tasks:
         sudo darwin-rebuild switch --flake .#{{.HOST}}
       {{else}}
         {{.NIX_CONFIG_PREFIX}}nix run "{{.HOME_MANAGER_APP}}" -- switch --flake "{{.HOME_FLAKE}}"
+        _zsh="$HOME/.nix-profile/bin/zsh"
+        if [ -x "$_zsh" ] && [ "$(grep -m1 "^$USER:" /etc/passwd | cut -d: -f7)" != "$_zsh" ]; then
+          grep -qxF "$_zsh" /etc/shells 2>/dev/null || printf '%s\n' "$_zsh" | sudo tee -a /etc/shells >/dev/null
+          sudo usermod -s "$_zsh" "$USER" || chsh -s "$_zsh" || printf 'Note: run: sudo usermod -s %s %s\n' "$_zsh" "$USER"
+        fi
       {{end}}
 
   # Maintenance
@@ -571,4 +582,9 @@ tasks:
         {{.NIX_CONFIG_PREFIX}}{{.ROOT_CMD}} nixos-rebuild switch --flake "{{.SYSTEM_FLAKE}}"
       {{else}}
         {{.NIX_CONFIG_PREFIX}}nix run "{{.HOME_MANAGER_APP}}" -- switch --flake "{{.HOME_FLAKE}}"
+        _zsh="$HOME/.nix-profile/bin/zsh"
+        if [ -x "$_zsh" ] && [ "$(grep -m1 "^$USER:" /etc/passwd | cut -d: -f7)" != "$_zsh" ]; then
+          grep -qxF "$_zsh" /etc/shells 2>/dev/null || printf '%s\n' "$_zsh" | sudo tee -a /etc/shells >/dev/null
+          sudo usermod -s "$_zsh" "$USER" || chsh -s "$_zsh" || printf 'Note: run: sudo usermod -s %s %s\n' "$_zsh" "$USER"
+        fi
       {{end}}


### PR DESCRIPTION
## Summary

- Bump all versioned inputs 25.11 → 26.05 (nixpkgs, home-manager, nix-darwin, stylix); update stateVersion to match
- Replace deprecated `xorg.libX*` attrs with flat names (`libx11`, etc.) across `flake.nix` and `home-manager/home-wsl.nix`
- Switch `docker` → `docker_29`; remove `checkovPatched`/`python3Patched` to restore binary cache hits; skip `pipx` 1.8.0 PEP-508 test failures via `overridePythonAttrs`
- Wire nix-community.cachix.org via `nixConfig` + `nix.custom.conf` (Determinate Systems owns `nix.conf`)
- Bootstrap: soft-fail `install-go-tools.sh` when `go` not on PATH; apt-install `git`/`curl` in `.envrc`; add `CHEZMOI` taskfile var with `nix shell` fallback; fix `install.sh` step 8 to include `nixpkgs#chezmoi`
- Login shell: `direnv` bash integration; `sudo -n usermod` in activation; interactive `usermod`/`chsh` in `home-switch`/`upgrade` tasks
- Bake `gh auth git-credential` helper into home-manager git config so `gh auth login` does not attempt to write to the read-only nix store symlink

## Test plan

- [ ] Fresh Debian WSL: `bash install.sh` completes without errors
- [ ] `task upgrade` sets login shell to nix zsh (`grep jhettenh /etc/passwd`)
- [ ] No `untrusted substituter` warnings after `nix.custom.conf` is written
- [ ] `pipx` builds without test failures
- [ ] `gh auth login` succeeds without permission errors on git config

🤖 Generated with [Claude Code](https://claude.com/claude-code)