### PR TITLE
feat: overmind-managed mdp-local stack + Skill-invocation hook logging

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,8 +118,8 @@ within the nix-config repo. Prefer these over ad-hoc shell one-liners when
 they fit the task.
 
 Automation scripts **not** intended for manual invocation (the hook loggers
-`log-bash.sh` / `log-thinking.sh`, `compress-old-cache`, `claude-cache-stats`,
-and the `aws-mcp-server` MCP wrapper) live one level down in
+`log-bash.sh` / `log-skill.sh` / `log-thinking.sh`, `compress-old-cache`,
+`claude-cache-stats`, and the `aws-mcp-server` MCP wrapper) live one level down in
 `~/.local/bin/ai-tools/` (source: `chezmoi/dot_local/bin/ai-tools/`). That
 subdirectory is deliberately **not** on `$PATH` — these are invoked by agent
 hooks / MCP clients via absolute path, not by name.
@@ -172,6 +172,24 @@ hooks / MCP clients via absolute path, not by name.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-skill.sh`** — Skill-invocation hook logger; **not run by hand**. Wired
+  for Claude via the `PostToolUse` `Skill` matcher in
+  `~/.config/claude/settings.json` (injected by the `ensureClaudeHook`
+  activation) and for Copilot via `~/.config/copilot/hooks/log-skill.json`. For
+  every `Skill` tool call — **model-initiated (automatic) invocations as well as
+  skill slash-commands** — it appends a record to
+  `~/.cache/copilot/session_<id>.skills.log`:
+
+  ```text
+  ## [YYYY-MM-DD HH:MM:SS] skill=<name> cwd=<dir>
+  ARGS: <args>
+  RESULT:   (only when the tool response carries text; large output truncated)
+  ```
+
+  Built-in commands like `/model` or `/clear` do **not** route through the Skill
+  tool and are intentionally not captured. Grep `^## ` across
+  `session_*.skills.log` for a skill-usage timeline. Handles both Claude
+  (`tool_input.skill`) and Copilot (`toolName`) payload shapes.
 - **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
   Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
   new reasoning to `~/.cache/copilot/session_<id>.thinking.log`, deduped by a

--- a/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
@@ -121,8 +121,8 @@ within the nix-config repo. Prefer these over ad-hoc shell one-liners when
 they fit the task.
 
 Automation scripts **not** intended for manual invocation (the hook loggers
-`log-bash.sh` / `log-thinking.sh`, `compress-old-cache`, `claude-cache-stats`,
-and the `aws-mcp-server` MCP wrapper) live one level down in
+`log-bash.sh` / `log-skill.sh` / `log-thinking.sh`, `compress-old-cache`,
+`claude-cache-stats`, and the `aws-mcp-server` MCP wrapper) live one level down in
 `~/.local/bin/ai-tools/` (source: `chezmoi/dot_local/bin/ai-tools/`). That
 subdirectory is deliberately **not** on `$PATH` — these are invoked by agent
 hooks / MCP clients via absolute path, not by name.
@@ -175,6 +175,24 @@ hooks / MCP clients via absolute path, not by name.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-skill.sh`** — Skill-invocation hook logger; **not run by hand**. Wired
+  for Claude via the `PostToolUse` `Skill` matcher in
+  `~/.config/claude/settings.json` (injected by the `ensureClaudeHook`
+  activation) and for Copilot via `~/.config/copilot/hooks/log-skill.json`. For
+  every `Skill` tool call — **model-initiated (automatic) invocations as well as
+  skill slash-commands** — it appends a record to
+  `~/.cache/copilot/session_<id>.skills.log`:
+
+  ```text
+  ## [YYYY-MM-DD HH:MM:SS] skill=<name> cwd=<dir>
+  ARGS: <args>
+  RESULT:   (only when the tool response carries text; large output truncated)
+  ```
+
+  Built-in commands like `/model` or `/clear` do **not** route through the Skill
+  tool and are intentionally not captured. Grep `^## ` across
+  `session_*.skills.log` for a skill-usage timeline. Handles both Claude
+  (`tool_input.skill`) and Copilot (`toolName`) payload shapes.
 - **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
   Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
   new reasoning to `~/.cache/copilot/session_<id>.thinking.log`, deduped by a

--- a/chezmoi/dot_config/claude/CLAUDE.md
+++ b/chezmoi/dot_config/claude/CLAUDE.md
@@ -118,8 +118,8 @@ within the nix-config repo. Prefer these over ad-hoc shell one-liners when
 they fit the task.
 
 Automation scripts **not** intended for manual invocation (the hook loggers
-`log-bash.sh` / `log-thinking.sh`, `compress-old-cache`, `claude-cache-stats`,
-and the `aws-mcp-server` MCP wrapper) live one level down in
+`log-bash.sh` / `log-skill.sh` / `log-thinking.sh`, `compress-old-cache`,
+`claude-cache-stats`, and the `aws-mcp-server` MCP wrapper) live one level down in
 `~/.local/bin/ai-tools/` (source: `chezmoi/dot_local/bin/ai-tools/`). That
 subdirectory is deliberately **not** on `$PATH` — these are invoked by agent
 hooks / MCP clients via absolute path, not by name.
@@ -172,6 +172,24 @@ hooks / MCP clients via absolute path, not by name.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-skill.sh`** — Skill-invocation hook logger; **not run by hand**. Wired
+  for Claude via the `PostToolUse` `Skill` matcher in
+  `~/.config/claude/settings.json` (injected by the `ensureClaudeHook`
+  activation) and for Copilot via `~/.config/copilot/hooks/log-skill.json`. For
+  every `Skill` tool call — **model-initiated (automatic) invocations as well as
+  skill slash-commands** — it appends a record to
+  `~/.cache/claude/session_<id>.skills.log`:
+
+  ```text
+  ## [YYYY-MM-DD HH:MM:SS] skill=<name> cwd=<dir>
+  ARGS: <args>
+  RESULT:   (only when the tool response carries text; large output truncated)
+  ```
+
+  Built-in commands like `/model` or `/clear` do **not** route through the Skill
+  tool and are intentionally not captured. Grep `^## ` across
+  `session_*.skills.log` for a skill-usage timeline. Handles both Claude
+  (`tool_input.skill`) and Copilot (`toolName`) payload shapes.
 - **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
   Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
   new reasoning to `~/.cache/claude/session_<id>.thinking.log`, deduped by a

--- a/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
@@ -121,8 +121,8 @@ within the nix-config repo. Prefer these over ad-hoc shell one-liners when
 they fit the task.
 
 Automation scripts **not** intended for manual invocation (the hook loggers
-`log-bash.sh` / `log-thinking.sh`, `compress-old-cache`, `claude-cache-stats`,
-and the `aws-mcp-server` MCP wrapper) live one level down in
+`log-bash.sh` / `log-skill.sh` / `log-thinking.sh`, `compress-old-cache`,
+`claude-cache-stats`, and the `aws-mcp-server` MCP wrapper) live one level down in
 `~/.local/bin/ai-tools/` (source: `chezmoi/dot_local/bin/ai-tools/`). That
 subdirectory is deliberately **not** on `$PATH` — these are invoked by agent
 hooks / MCP clients via absolute path, not by name.
@@ -175,6 +175,24 @@ hooks / MCP clients via absolute path, not by name.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-skill.sh`** — Skill-invocation hook logger; **not run by hand**. Wired
+  for Claude via the `PostToolUse` `Skill` matcher in
+  `~/.config/claude/settings.json` (injected by the `ensureClaudeHook`
+  activation) and for Copilot via `~/.config/copilot/hooks/log-skill.json`. For
+  every `Skill` tool call — **model-initiated (automatic) invocations as well as
+  skill slash-commands** — it appends a record to
+  `~/.cache/copilot/session_<id>.skills.log`:
+
+  ```text
+  ## [YYYY-MM-DD HH:MM:SS] skill=<name> cwd=<dir>
+  ARGS: <args>
+  RESULT:   (only when the tool response carries text; large output truncated)
+  ```
+
+  Built-in commands like `/model` or `/clear` do **not** route through the Skill
+  tool and are intentionally not captured. Grep `^## ` across
+  `session_*.skills.log` for a skill-usage timeline. Handles both Claude
+  (`tool_input.skill`) and Copilot (`toolName`) payload shapes.
 - **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
   Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
   new reasoning to `~/.cache/copilot/session_<id>.thinking.log`, deduped by a

--- a/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
+++ b/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
@@ -121,8 +121,8 @@ within the nix-config repo. Prefer these over ad-hoc shell one-liners when
 they fit the task.
 
 Automation scripts **not** intended for manual invocation (the hook loggers
-`log-bash.sh` / `log-thinking.sh`, `compress-old-cache`, `claude-cache-stats`,
-and the `aws-mcp-server` MCP wrapper) live one level down in
+`log-bash.sh` / `log-skill.sh` / `log-thinking.sh`, `compress-old-cache`,
+`claude-cache-stats`, and the `aws-mcp-server` MCP wrapper) live one level down in
 `~/.local/bin/ai-tools/` (source: `chezmoi/dot_local/bin/ai-tools/`). That
 subdirectory is deliberately **not** on `$PATH` — these are invoked by agent
 hooks / MCP clients via absolute path, not by name.
@@ -175,6 +175,24 @@ hooks / MCP clients via absolute path, not by name.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-skill.sh`** — Skill-invocation hook logger; **not run by hand**. Wired
+  for Claude via the `PostToolUse` `Skill` matcher in
+  `~/.config/claude/settings.json` (injected by the `ensureClaudeHook`
+  activation) and for Copilot via `~/.config/copilot/hooks/log-skill.json`. For
+  every `Skill` tool call — **model-initiated (automatic) invocations as well as
+  skill slash-commands** — it appends a record to
+  `~/.cache/copilot/session_<id>.skills.log`:
+
+  ```text
+  ## [YYYY-MM-DD HH:MM:SS] skill=<name> cwd=<dir>
+  ARGS: <args>
+  RESULT:   (only when the tool response carries text; large output truncated)
+  ```
+
+  Built-in commands like `/model` or `/clear` do **not** route through the Skill
+  tool and are intentionally not captured. Grep `^## ` across
+  `session_*.skills.log` for a skill-usage timeline. Handles both Claude
+  (`tool_input.skill`) and Copilot (`toolName`) payload shapes.
 - **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
   Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
   new reasoning to `~/.cache/copilot/session_<id>.thinking.log`, deduped by a

--- a/chezmoi/dot_config/instructions/agent-defaults.md
+++ b/chezmoi/dot_config/instructions/agent-defaults.md
@@ -118,8 +118,8 @@ within the nix-config repo. Prefer these over ad-hoc shell one-liners when
 they fit the task.
 
 Automation scripts **not** intended for manual invocation (the hook loggers
-`log-bash.sh` / `log-thinking.sh`, `compress-old-cache`, `claude-cache-stats`,
-and the `aws-mcp-server` MCP wrapper) live one level down in
+`log-bash.sh` / `log-skill.sh` / `log-thinking.sh`, `compress-old-cache`,
+`claude-cache-stats`, and the `aws-mcp-server` MCP wrapper) live one level down in
 `~/.local/bin/ai-tools/` (source: `chezmoi/dot_local/bin/ai-tools/`). That
 subdirectory is deliberately **not** on `$PATH` — these are invoked by agent
 hooks / MCP clients via absolute path, not by name.
@@ -172,6 +172,24 @@ hooks / MCP clients via absolute path, not by name.
   `interrupted`, else `stderr` when stderr is non-empty, else `ok`. When reading
   logs directly, grep `^##` for a command timeline and
   `status=stderr|interrupted` for likely failures.
+- **`log-skill.sh`** — Skill-invocation hook logger; **not run by hand**. Wired
+  for Claude via the `PostToolUse` `Skill` matcher in
+  `~/.config/claude/settings.json` (injected by the `ensureClaudeHook`
+  activation) and for Copilot via `~/.config/copilot/hooks/log-skill.json`. For
+  every `Skill` tool call — **model-initiated (automatic) invocations as well as
+  skill slash-commands** — it appends a record to
+  `~/.cache/@@AGENT@@/session_<id>.skills.log`:
+
+  ```text
+  ## [YYYY-MM-DD HH:MM:SS] skill=<name> cwd=<dir>
+  ARGS: <args>
+  RESULT:   (only when the tool response carries text; large output truncated)
+  ```
+
+  Built-in commands like `/model` or `/clear` do **not** route through the Skill
+  tool and are intentionally not captured. Grep `^## ` across
+  `session_*.skills.log` for a skill-usage timeline. Handles both Claude
+  (`tool_input.skill`) and Copilot (`toolName`) payload shapes.
 - **`log-thinking.sh`** — agent-reasoning logger; **not run by hand**. Wired as
   Claude `Stop`/`SubagentStop` hooks and a Copilot `postToolUse` hook. Appends
   new reasoning to `~/.cache/@@AGENT@@/session_<id>.thinking.log`, deduped by a

--- a/chezmoi/dot_local/bin/ai-tools/executable_log-skill.sh
+++ b/chezmoi/dot_local/bin/ai-tools/executable_log-skill.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# log-skill.sh — PostToolUse hook logger for Skill (slash-command / Agent Skill)
+# invocations in Claude Code (and Copilot).
+#
+# NOT run by hand. It is wired as a Skill PostToolUse hook in settings.json and
+# receives the hook payload as JSON on stdin. For every Skill tool call it
+# appends a structured, greppable record to
+# ~/.cache/<agent>/session_<id>.skills.log:
+#
+#   ## [YYYY-MM-DD HH:MM:SS] skill=<name> cwd=<dir>
+#   ARGS: <args>
+#   RESULT:        # only present when the tool response carries text
+#   <result, large output truncated>
+#   ---
+#
+# This captures model-initiated (automatic) skill invocations as well as
+# user-typed skill slash-commands — anything that runs through the Skill tool.
+# Built-in commands like /model or /clear do NOT route through the Skill tool
+# and are intentionally not logged here. Mirrors log-bash.sh.
+set -euo pipefail
+
+input=$(cat)
+
+# Detect format by Copilot's camelCase "toolName" vs Claude Code's "tool_name".
+if printf '%s' "$input" | jq -e '.toolName' >/dev/null 2>&1; then
+	# Copilot postToolUse: toolArgs is a JSON string.
+	tool_name=$(printf '%s' "$input" | jq -r '.toolName // ""')
+	[[ "$tool_name" == "Skill" || "$tool_name" == "skill" ]] || exit 0
+	skill=$(printf '%s' "$input" | jq -r '(.toolArgs | fromjson | .skill) // ""' 2>/dev/null || echo "")
+	args=$(printf '%s' "$input" | jq -r '(.toolArgs | fromjson | .args) // ""' 2>/dev/null || echo "")
+	sid=$(printf '%s' "$input" | jq -r '.sessionId // "nosid"')
+	cwd=$(printf '%s' "$input" | jq -r '.cwd // .workspaceRoot // ""')
+	result=$(printf '%s' "$input" | jq -r '.toolResult.textResultForLlm // ""')
+else
+	# Claude Code PostToolUse: tool_input is an object {skill, args}.
+	tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""')
+	[[ "$tool_name" == "Skill" ]] || exit 0
+	skill=$(printf '%s' "$input" | jq -r '.tool_input.skill // ""')
+	args=$(printf '%s' "$input" | jq -r '.tool_input.args // ""')
+	sid=$(printf '%s' "$input" | jq -r '.session_id // "nosid"')
+	cwd=$(printf '%s' "$input" | jq -r '.cwd // ""')
+	result=$(printf '%s' "$input" | jq -r '
+		if (.tool_response | type) == "object" then
+			(.tool_response.content // .tool_response.stdout // .tool_response.result // "")
+		elif (.tool_response | type) == "string" then .tool_response
+		else "" end')
+fi
+
+agent_raw="${AGENT_NAME:-claude}"
+agent=$(printf '%s' "$agent_raw" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9._-')
+[[ -n "$agent" ]] || agent="claude"
+
+# Cap very large fields so individual records stay scannable. Character-based
+# slicing (no pipe) avoids SIGPIPE under `set -o pipefail`.
+max_chars=8000
+truncate_field() {
+	local data="$1"
+	if ((${#data} > max_chars)); then
+		printf '%s\n... [truncated %s of %s chars — see agent transcript for full output]' \
+			"${data:0:max_chars}" "$((${#data} - max_chars))" "${#data}"
+	else
+		printf '%s' "$data"
+	fi
+}
+
+log_dir="$HOME/.cache/$agent"
+logfile="$log_dir/session_${sid}.skills.log"
+mkdir -p "$log_dir"
+
+{
+	printf '\n## [%s] skill=%s cwd=%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${skill:-?}" "${cwd:-?}"
+	if [[ -n "$args" ]]; then
+		printf 'ARGS: %s\n' "$args"
+	fi
+	if [[ -n "$result" ]]; then
+		printf 'RESULT:\n%s\n' "$(truncate_field "$result")"
+	fi
+	printf -- '---\n'
+} >>"$logfile"

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -272,6 +272,22 @@ in {
         ];
       };
 
+      # Wires the Copilot skill-invocation logger. log-skill.sh self-filters on
+      # toolName == "Skill" and appends a record to
+      # ~/.cache/copilot/session_<id>.skills.log. Mirrors the Claude PostToolUse
+      # "Skill" hook injected by ensureClaudeHook below, so automatic
+      # (model-initiated) and slash-command skill calls are tracked for both agents.
+      "copilot/hooks/log-skill.json".text = builtins.toJSON {
+        version = 1;
+        hooks.postToolUse = [
+          {
+            type = "command";
+            command = ''AGENT_NAME=copilot exec bash "$HOME/.local/bin/ai-tools/log-skill.sh"'';
+            timeoutSec = 10;
+          }
+        ];
+      };
+
       # Copilot CLI MCP servers, managed declaratively so the set stays lean.
       # Every enabled MCP server injects its tool definitions into context on
       # each agent step — input tokens on every turn under Copilot's
@@ -398,6 +414,17 @@ in {
           _tmp=$(${pkgs.coreutils}/bin/mktemp)
           jq \
             '.hooks.PostToolUse |= (. // []) + [{"matcher":"Bash","hooks":[{"type":"command","command":"AGENT_NAME=claude bash \"$HOME/.local/bin/ai-tools/log-bash.sh\"","async":true}]}]' \
+            "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
+        fi
+        # PostToolUse "Skill": log skill invocations (model-initiated auto-calls
+        # and skill slash-commands) to ~/.cache/claude/session_<id>.skills.log via
+        # log-skill.sh. The Skill tool carries the skill name in tool_input.skill;
+        # built-in commands like /model never route through it. Idempotent guard
+        # mirrors the Bash hook above.
+        if ! jq -e '.hooks.PostToolUse[]? | select(.matcher == "Skill")' "$_settings" > /dev/null 2>&1; then
+          _tmp=$(${pkgs.coreutils}/bin/mktemp)
+          jq \
+            '.hooks.PostToolUse |= (. // []) + [{"matcher":"Skill","hooks":[{"type":"command","command":"AGENT_NAME=claude bash \"$HOME/.local/bin/ai-tools/log-skill.sh\"","async":true}]}]' \
             "$_settings" > "$_tmp" && ${pkgs.coreutils}/bin/mv "$_tmp" "$_settings"
         fi
         # SessionEnd: append a one-line prompt-cache summary per session. Fires

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -204,6 +204,9 @@
       autoUpdate = true;
       upgrade = true;
       cleanup = "zap"; # Uninstall packages not listed in configuration
+      # Homebrew 4.7+ refuses `brew bundle install --cleanup` without an
+      # explicit force flag; nix-darwin doesn't add one, so pass it here.
+      extraFlags = ["--force-cleanup"];
     };
 
     # Taps (third-party repositories)


### PR DESCRIPTION
## Summary

Two related commits building on the agent-tooling stack:

- **`feat(mdp-local)`** — overmind-managed local stack with daemonized auto-attach.
- **`feat(hooks)`** — `log-skill.sh` `PostToolUse` hook logger that records Skill
  tool calls (both model-initiated automatic invocations and slash-command
  invocations) to `~/.cache/<agent>/session_<id>.skills.log` for Claude and
  Copilot.

## Skill logging details

- New `chezmoi/dot_local/bin/ai-tools/executable_log-skill.sh` handles both
  Claude (`tool_input.skill`) and Copilot (`toolName`/`toolArgs`) payload shapes,
  self-filters on the `Skill` tool, and writes greppable
  `## [timestamp] skill=<name> cwd=<dir>` records with `ARGS:`/`RESULT:` fields.
- Claude wiring: idempotent `"Skill"` `PostToolUse` matcher injected by
  `ensureClaudeHook` in `home-manager/common.nix`.
- Copilot wiring: `copilot/hooks/log-skill.json` `postToolUse` entry.
- Built-in commands like `/model` and `/clear` do not route through the Skill
  tool and are intentionally not captured.
- `agent-defaults.md` documents the script; the mirrored agent-instruction files
  (`.github/copilot-instructions.md`, chezmoi Claude/Copilot/IntelliJ/VS Code
  variants) were regenerated via `task generate:agent-instructions`.

## Test plan

- [x] Pre-commit suite passes (statix, deadnix, instruction-sync checks,
  instruction-size budget, gitleaks).
