### PR TITLE
docs(vscode): document required claudeCode.useTerminal setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,18 @@ task generate:agent-instructions
 
 The pre-commit hook and CI catch drift automatically via `task check:agent-instructions`.
 
+### Claude Code VS Code extension
+
+The shared VS Code user settings in `home-manager/lib/code-editor-user-settings.nix`
+set `claudeCode.useTerminal = true`, which launches the Claude CLI in the integrated
+terminal instead of the extension's native UI. This is **required** for this config:
+the terminal session is what loads the managed zsh environment (nix-provided `rg`/`fd`/
+`jq` and friends, aliases, PATH) and triggers the `log-bash.sh` / `log-skill.sh` /
+`log-thinking.sh` hooks that feed `~/.cache/claude` and `cache-scan`. Running Claude in
+the native UI bypasses that shell and its hook pipeline. If you toggle it off in the VS
+Code Settings UI (Extensions → Claude Code → "Use Terminal"), the next `home-switch`
+restores it.
+
 ### Agent activity logs & `cache-scan`
 
 Agent sessions are logged to `~/.cache/<agent>/` (with `~/.cache/claude` symlinked

--- a/home-manager/lib/code-editor-user-settings.nix
+++ b/home-manager/lib/code-editor-user-settings.nix
@@ -71,6 +71,7 @@
     };
     "https://*.gov/*" = true;
   };
+  "claudeCode.useTerminal" = true;
   "cSpell.enabled" = false;
   "git.blame.editorDecoration.enabled" = true;
   "git.autofetch" = true;


### PR DESCRIPTION
## Summary

Sets `claudeCode.useTerminal = true` in the shared VS Code user settings and documents in the README why it is required for this configuration.

## Why

The Claude Code VS Code extension can run either in the integrated terminal or in a native UI. This repo depends on the **terminal** path because that session:

- loads the managed zsh environment (nix-provided `rg`/`fd`/`jq`, aliases, PATH), and
- triggers the `log-bash.sh` / `log-skill.sh` / `log-thinking.sh` hooks that feed `~/.cache/claude` and `cache-scan`.

The native UI bypasses that shell and its hook pipeline, so the setting is pinned on and documented under a new **Claude Code VS Code extension** subsection in the README. Toggling it off in the Settings UI is reverted on the next `home-switch`.

## Changes

- `home-manager/lib/code-editor-user-settings.nix` — add `"claudeCode.useTerminal" = true;`
- `README.md` — new subsection explaining the requirement

## Notes

`flake.lock` had a pre-existing unrelated modification in the working tree; it is intentionally **not** part of this PR.