### PR TITLE
fix(switch): filter HM orphan-link spam + pin CLI agents to nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,6 +234,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": [
@@ -288,6 +304,7 @@
         "nix-darwin": "nix-darwin",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
         "sops-nix": "sops-nix",
         "stylix": "stylix"

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
+    # Tracks fast-moving upstream releases (currently used only for the
+    # claude-code / github-copilot-cli overlay below — nixos-26.05 lags
+    # Anthropic/GitHub Copilot CLI releases by days-to-weeks).
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-wsl = {
       url = "github:nix-community/NixOS-WSL/main";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -47,6 +51,7 @@
 
   outputs = {
     nixpkgs,
+    nixpkgs-unstable,
     nixos-wsl,
     nix-darwin,
     home-manager,
@@ -55,6 +60,17 @@
     sops-nix,
     ...
   }: let
+    # Pin fast-moving CLI agents to nixos-unstable while the rest of the
+    # repo stays on nixos-26.05. See AGENTS.md / docs notes if expanded.
+    unstableOverlay = _final: prev: let
+      unstable = import nixpkgs-unstable {
+        system = prev.stdenv.hostPlatform.system;
+        config.allowUnfree = true;
+      };
+    in {
+      inherit (unstable) claude-code github-copilot-cli;
+    };
+    nixpkgsOverlayModule = {nixpkgs.overlays = [unstableOverlay];};
     systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
     linuxSystems = ["x86_64-linux" "aarch64-linux"];
     forAllSystems = nixpkgs.lib.genAttrs systems;
@@ -99,6 +115,7 @@
     goGuiLibraryPathFor = pkgs: nixpkgs.lib.makeLibraryPath (goGuiRuntimePackagesFor pkgs);
     darwinModules = [
       ./hosts/darwin
+      nixpkgsOverlayModule
 
       stylix.darwinModules.stylix
       sops-nix.darwinModules.default
@@ -130,6 +147,7 @@
           allowUnfree = true;
           allowUnfreePredicate = _: true;
         };
+        overlays = [unstableOverlay];
       };
     repoDevShellFor = pkgs:
       pkgs.mkShell {
@@ -173,6 +191,7 @@
         system = "x86_64-linux";
         modules = [
           ./hosts/linux
+          nixpkgsOverlayModule
 
           stylix.nixosModules.stylix
           sops-nix.nixosModules.sops
@@ -204,6 +223,7 @@
         system = "x86_64-linux";
         modules = [
           nixos-wsl.nixosModules.default
+          nixpkgsOverlayModule
           home-manager.nixosModules.home-manager
           sops-nix.nixosModules.sops
           ./hosts/wsl

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -222,7 +222,14 @@ tasks:
         nix run .#home-manager -- switch --flake .#"{{.DEVCONTAINER_ATTR}}" -b bak-devcontainer
       {{else if eq .IS_DARWIN "true"}}
         brew update --quiet
-        sudo darwin-rebuild switch --flake .#{{.HOST}}
+        # Strip Home Manager's cosmetic orphan-link spam (~530 lines/run) left by
+        # the stale *.instructions.md -> *.prompt.md prompt-bridge migration; the
+        # referenced files are already gone. pipefail + a brace-grouped `|| true`
+        # drops only those lines while preserving darwin-rebuild's exit code and
+        # every other line, including genuine errors.
+        set -o pipefail
+        sudo darwin-rebuild switch --flake .#{{.HOST}} 2>&1 \
+          | { grep -v 'does not link into a Home Manager generation\. Skipping delete\.' || true; }
       {{else if eq .IS_NIXOS "true"}}
         bash scripts/nixos-switch-tolerant.sh "{{.SYSTEM_FLAKE}}"
       {{else}}


### PR DESCRIPTION
Two changes on the same branch.

## 1. Filter Home Manager orphan-link spam (`taskfile.yaml`)

`task switch` on darwin prints **~530** `does not link into a Home Manager generation. Skipping delete.` lines on **every run** — orphan-link cleanup left over from the stale `*.instructions.md` → `*.prompt.md` prompt-bridge migration. The referenced files are already gone on disk, so the messages are purely cosmetic, but they bury the genuine errors in the switch output.

Pipes `darwin-rebuild switch` through `grep -v` for that one message.

**Safe:** `set -o pipefail` + a brace-grouped `|| true` preserves `darwin-rebuild`'s real exit code (a failed switch still fails); stderr is merged via `2>&1` so real errors pass through — only the orphan-link line is dropped.

**Verified** on darwin: orphan lines **530 → 0**, switch log **714 → 193 lines**, exit code **0** preserved, unrelated chrome/slack cask-upgrade errors still visible (not masked).

## 2. Pin `claude-code` + `github-copilot-cli` to nixos-unstable (`flake.nix`, `flake.lock`)

nixos-26.05 lags Anthropic/GitHub Copilot CLI releases by days-to-weeks. Adds a `nixpkgs-unstable` input and an overlay that sources **only** those two packages from it, leaving the rest of the repo on nixos-26.05.