### PR TITLE
fix(cache-logs): stop misclassifying benign noise and surface exit-0 failures

### DIFF
--- a/ai-tools/scripts/log-bash.sh
+++ b/ai-tools/scripts/log-bash.sh
@@ -61,6 +61,21 @@ agent_raw="${AGENT_NAME:-claude}"
 agent=$(printf '%s' "$agent_raw" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9._-')
 [[ -n "$agent" ]] || agent="claude"
 
+# Strip benign noise from stderr before deciding status. The hook gets no exit
+# code, so any non-empty stderr would otherwise read as a failure — but two
+# common lines are not failures:
+#   - "Shell cwd was reset to <dir>": Claude Code emits this after a one-shot
+#     `cd`, even when the command succeeded.
+#   - "...Broken pipe": SIGPIPE from a producer feeding an early-closing
+#     consumer (e.g. `... | head`), which is expected, not an error.
+# Drop those lines; if nothing substantive remains, treat stderr as empty so
+# status falls through to `ok` and no STDERR block is logged. Keep this list
+# small and obvious — only add lines that are unambiguously harness noise.
+if [[ -n "$stderr" ]]; then
+	stderr=$(printf '%s\n' "$stderr" | grep -Eiv 'Shell cwd was reset to |broken pipe' || true)
+	[[ -n "${stderr//[[:space:]]/}" ]] || stderr=""
+fi
+
 if [[ "$interrupted" == "true" ]]; then
 	status="interrupted"
 elif [[ -n "$stderr" ]]; then

--- a/ai-tools/skills/sec-credentials/SKILL.md
+++ b/ai-tools/skills/sec-credentials/SKILL.md
@@ -38,6 +38,25 @@ Use this skill when a task needs a credential and you don't yet know where to fi
 source ~/.local/bin/kac ensure
 ```
 
+**Run `kac ensure` *before* the first `aws` call, not as recovery after one
+fails.** Firing `aws` against an inherited stale token wastes round-trips on
+`ExpiredTokenException` and then sends agents off exploring. For a one-shot,
+non-interactive invocation, wrap both in one zsh command so the refresh always
+precedes the call:
+
+```bash
+zsh -lc 'source ~/.local/bin/kac ensure >/dev/null && aws sts get-caller-identity --output text'
+```
+
+Anti-patterns (observed wasting time in real sessions):
+
+- **Do not reach for `aws sso login`** — Kion, not raw SSO, owns auth here; `kac`
+  refreshes via `gkion` for you.
+- **Do not `find` / `zstdcat` for the cache location.** `kac` owns
+  `~/.cache/kion-aws-cache/`; the path is documented here and in
+  `agent-reference.md`. Re-deriving it from cold burns tokens and risks a stale
+  path.
+
 If you can't source `kac`, read the cached values directly:
 
 ```bash

--- a/ai-tools/skills/sec-credentials/SKILL.md
+++ b/ai-tools/skills/sec-credentials/SKILL.md
@@ -21,13 +21,32 @@ Use this skill when a task needs a credential and you don't yet know where to fi
    Tools that cache short-lived session state (browser cookies, refreshed OAuth tokens, kerberos tickets) typically write here. Check this before prompting if a session-style credential is needed.
 
 4. **Legacy / tool-default path** — whatever the tool's docs specify (`~/.aws/credentials`, `~/.kube/config`, `~/.netrc`).
-   These are fallback locations the tool consults when XDG isn't honored. Some tools (notably `gh`) use the XDG path now; older ones still write here.
+   These are fallback locations the tool consults when XDG isn't honored. Some tools (notably `gh`) use the XDG path now; older ones still write here. **AWS is the trap here:** `~/.aws/credentials` and `AWS_PROFILE` are frequently stale and raise `ExpiredTokenException` — see the AWS section below before reaching for them.
 
 5. **Last resort: prompt the user.** Only after the above four paths have all been checked.
 
 ## Canonical example
 
 [home-manager/local/bin/ops-agent.py](../../../home-manager/local/bin/ops-agent.py) implements this pattern for the Jira token: read `~/.config/ops-agent/jira-token` (sops-decrypted), fall back to `~/.config/jira/token` (legacy), then error out. That precedence chain is the template — any new credential consumer in this repo should follow the same layering.
+
+## AWS credentials (Kion)
+
+**Do not trust `~/.aws/credentials` or `AWS_PROFILE`** — they are usually stale and produce `ExpiredTokenException`. The live AWS session lives in the Kion credential cache at `~/.cache/kion-aws-cache/`. Prefer the `kac` helper, which loads from that cache and auto-refreshes via `gkion` when it's empty or expired:
+
+```bash
+# Preferred: load valid creds into the current shell (must be sourced, zsh only)
+source ~/.local/bin/kac ensure
+```
+
+If you can't source `kac`, read the cached values directly:
+
+```bash
+export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
+export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
+export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
+```
+
+If an `aws` call fails with an expired-token error, the inherited env vars (`AWS_ACCESS_KEY_ID`, etc.) are likely overriding the cache — clear them and re-source `kac` rather than editing `~/.aws/credentials`. Full `kac` subcommand reference is in `agent-reference.md`.
 
 ## Quick checks
 

--- a/ai-tools/skills/shell-pitfalls/SKILL.md
+++ b/ai-tools/skills/shell-pitfalls/SKILL.md
@@ -83,6 +83,25 @@ For the specific case of `gh api graphql` calls and long/nested `jq` filters —
 
 When the local environment uses Kion, load temporary AWS credentials with `source ~/.local/bin/kac ensure` (or read `~/.cache/kion-aws-cache/`) rather than the frequently-stale `~/.aws/credentials` / `AWS_PROFILE`. Treat any value read from a credentials file as a secret — never echo it into command output or a summary.
 
+## `stat`: GNU shadows BSD, even on macOS
+
+On these hosts nix `coreutils` puts **GNU `stat`** on `PATH` ahead of the macOS
+BSD `stat` — on darwin and Linux alike. So BSD format syntax silently fails:
+
+```bash
+# Wrong on these hosts: GNU stat reads -f as --file-system and treats '%Sm' as a
+# filename → "stat: cannot read file system information for '%Sm': No such file…"
+stat -f '%Sm' ~/.aws/config
+
+# Right: GNU format syntax
+stat -c '%y' ~/.aws/config        # mtime
+stat -c '%A %n' ~/.aws/config     # mode + name
+```
+
+If you need a portable mtime regardless of which `stat` wins, sidestep it:
+`eza -l --time-style=long-iso <file>` or `date -r <file>`. The repo's own
+scripts assume GNU `stat -c` for this reason (see `cache-scan`'s header note).
+
 ## Wrapped-capture permission-denied retry
 
 Some IDE harnesses wrap shell invocations in a capture command that tightens the executing process's permissions. If a script that *should* be executable returns `permission denied` only when wrapped — but works on a manual run — try invoking it with an explicit `/bin/zsh -f`:
@@ -104,7 +123,7 @@ If you've reached this skill but none of the above patterns match, the problem p
 - Is the binary actually installed? `command -v <name>` (use `command`, not `which` — `which` is itself shell-specific in zsh).
 - Is `$PATH` what you expect? Aliases and `direnv` can mutate it inside the shell only.
 - Is the working directory what you expect? Shell history and IDE harnesses can confuse `cwd`.
-- Is the file mode actually executable? `stat -c '%A %n' <file>` (Linux) or `stat -f '%Sp %N' <file>` (macOS).
+- Is the file mode actually executable? `stat -c '%A %n' <file>` — GNU syntax on every host here, including macOS (see the `stat` section above; BSD `-f` syntax breaks).
 
 After ruling those out, check [ops-nix-pitfalls](../ops-nix-pitfalls/SKILL.md) for nix-specific traps that surface as shell errors.
 

--- a/chezmoi/dot_config/instructions/agent-reference.md
+++ b/chezmoi/dot_config/instructions/agent-reference.md
@@ -35,6 +35,10 @@ Lookup order: `~/.cache` first, then `~/.config`. Known locations by service:
   source ~/.local/bin/kac ensure
   ```
 
+  Do this **before** the first `aws` call, not after one fails — for a one-shot,
+  wrap both: `zsh -lc 'source ~/.local/bin/kac ensure >/dev/null && aws …'`. Do
+  not `aws sso login` or `find`/`zstdcat` for the cache path; `kac` owns it.
+
 - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
 - **SOPS age key** (decrypts all nix-managed secrets):
   `~/.config/sops/age/keys.txt`

--- a/chezmoi/dot_local/bin/executable_cache-scan
+++ b/chezmoi/dot_local/bin/executable_cache-scan
@@ -172,15 +172,59 @@ for f in "${logs[@]}"; do
 done
 
 # Likely failures — compact (time-only stamp, capped). The high-signal section.
+# Suppresses stderr records whose STDERR body is *only* benign harness noise
+# (the "Shell cwd was reset" one-shot-cd notice, SIGPIPE "Broken pipe"), so logs
+# written before the log-bash.sh stderr filter do not crowd out real failures.
+# `interrupted` records are never suppressed. Emission is deferred to record end
+# so the whole STDERR body can be inspected first.
 echo "FAILURES (stderr|interrupted)"
 fail_out=$(for f in "${logs[@]}"; do
 	catlog "$f" | awk -v file="${f##*/}" "$AWK_HDR"'
-		/^## \[/ { hdr($0); bad=(st=="stderr"||st=="interrupted"); pstamp=stamp; pst=st; next }
-		/^CMD: / && bad { printf "  %-8s %s %-11s :: %s\n", idof(file), hhmmss(pstamp), pst, substr($0,6); bad=0 }
+		function emit() {
+			if (!bad) return
+			if (pst=="stderr" && haderr && benign) return
+			printf "  %-8s %s %-11s :: %s\n", idof(file), hhmmss(pstamp), pst, cmd
+		}
+		/^## \[/ { emit(); hdr($0); bad=(st=="stderr"||st=="interrupted")
+			pstamp=stamp; pst=st; cmd=""; inerr=0; benign=1; haderr=0; next }
+		/^CMD: / && bad && cmd=="" { cmd=substr($0,6); next }
+		/^STDERR:/ && bad { inerr=1; next }
+		/^---$/ { inerr=0 }
+		inerr && bad && $0 !~ /^[[:space:]]*$/ {
+			haderr=1
+			if ($0 !~ /Shell cwd was reset to / && $0 !~ /[Bb]roken pipe/) benign=0
+		}
+		END { emit() }
 	'
 done | tail -n 12)
 if [[ -n "$fail_out" ]]; then
 	printf '%s\n' "$fail_out"
+else
+	echo "  none"
+fi
+
+# Silent failures — commands that exit cleanly but whose OUTPUT shows the action
+# did not happen: stale-credential AWS calls, zsh nullglob path misses, the
+# GNU/BSD `stat` format trap, missing binaries. These set no stderr, so the
+# status header above never flags them. Heuristic and body-scanned — CMD lines
+# are skipped so a command that merely *mentions* a marker is not flagged, but a
+# session that greps these logs can still self-trip; treat as a lead, not proof.
+echo "SILENT FAILURES (exit-0 errors, heuristic)"
+silent_out=$(for f in "${logs[@]}"; do
+	catlog "$f" | awk -v file="${f##*/}" "$AWK_HDR"'
+		function emit() { if (hit!="") printf "  %-8s %s %-13s :: %s\n", idof(file), hhmmss(pstamp), hit, cmd }
+		/^## \[/ { emit(); hdr($0); pstamp=stamp; cmd=""; hit=""; next }
+		/^CMD: / { if (cmd=="") cmd=substr($0,6); next }
+		hit!="" { next }
+		/ExpiredToken|security token included in the request is expired/ { hit="expired-token" }
+		/no matches found:/ { hit="nullglob-miss" }
+		/cannot read file system information for .%/ { hit="stat-dialect" }
+		/: command not found/ { hit="cmd-not-found" }
+		END { emit() }
+	'
+done | tail -n 12)
+if [[ -n "$silent_out" ]]; then
+	printf '%s\n' "$silent_out"
 else
 	echo "  none"
 fi

--- a/flake.lock
+++ b/flake.lock
@@ -234,6 +234,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": [
@@ -288,6 +304,7 @@
         "nix-darwin": "nix-darwin",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
         "sops-nix": "sops-nix",
         "stylix": "stylix"

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
+    # Tracks fast-moving upstream releases (currently used only for the
+    # claude-code / github-copilot-cli overlay below — nixos-26.05 lags
+    # Anthropic/GitHub Copilot CLI releases by days-to-weeks).
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-wsl = {
       url = "github:nix-community/NixOS-WSL/main";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -47,6 +51,7 @@
 
   outputs = {
     nixpkgs,
+    nixpkgs-unstable,
     nixos-wsl,
     nix-darwin,
     home-manager,
@@ -55,6 +60,17 @@
     sops-nix,
     ...
   }: let
+    # Pin fast-moving CLI agents to nixos-unstable while the rest of the
+    # repo stays on nixos-26.05. See AGENTS.md / docs notes if expanded.
+    unstableOverlay = _final: prev: let
+      unstable = import nixpkgs-unstable {
+        system = prev.stdenv.hostPlatform.system;
+        config.allowUnfree = true;
+      };
+    in {
+      inherit (unstable) claude-code github-copilot-cli;
+    };
+    nixpkgsOverlayModule = {nixpkgs.overlays = [unstableOverlay];};
     systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
     linuxSystems = ["x86_64-linux" "aarch64-linux"];
     forAllSystems = nixpkgs.lib.genAttrs systems;
@@ -99,6 +115,7 @@
     goGuiLibraryPathFor = pkgs: nixpkgs.lib.makeLibraryPath (goGuiRuntimePackagesFor pkgs);
     darwinModules = [
       ./hosts/darwin
+      nixpkgsOverlayModule
 
       stylix.darwinModules.stylix
       sops-nix.darwinModules.default
@@ -130,6 +147,7 @@
           allowUnfree = true;
           allowUnfreePredicate = _: true;
         };
+        overlays = [unstableOverlay];
       };
     repoDevShellFor = pkgs:
       pkgs.mkShell {
@@ -173,6 +191,7 @@
         system = "x86_64-linux";
         modules = [
           ./hosts/linux
+          nixpkgsOverlayModule
 
           stylix.nixosModules.stylix
           sops-nix.nixosModules.sops
@@ -204,6 +223,7 @@
         system = "x86_64-linux";
         modules = [
           nixos-wsl.nixosModules.default
+          nixpkgsOverlayModule
           home-manager.nixosModules.home-manager
           sops-nix.nixosModules.sops
           ./hosts/wsl

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -222,7 +222,14 @@ tasks:
         nix run .#home-manager -- switch --flake .#"{{.DEVCONTAINER_ATTR}}" -b bak-devcontainer
       {{else if eq .IS_DARWIN "true"}}
         brew update --quiet
-        sudo darwin-rebuild switch --flake .#{{.HOST}}
+        # Strip Home Manager's cosmetic orphan-link spam (~530 lines/run) left by
+        # the stale *.instructions.md -> *.prompt.md prompt-bridge migration; the
+        # referenced files are already gone. pipefail + a brace-grouped `|| true`
+        # drops only those lines while preserving darwin-rebuild's exit code and
+        # every other line, including genuine errors.
+        set -o pipefail
+        sudo darwin-rebuild switch --flake .#{{.HOST}} 2>&1 \
+          | { grep -v 'does not link into a Home Manager generation\. Skipping delete\.' || true; }
       {{else if eq .IS_NIXOS "true"}}
         bash scripts/nixos-switch-tolerant.sh "{{.SYSTEM_FLAKE}}"
       {{else}}


### PR DESCRIPTION
## Summary

Makes the agent cache-log `FAILURES` report show exactly what actually went
wrong — no more, no less. Two mirror-image problems in the log heuristic:

- **Class 1 — false failures.** Benign harness noise (`Shell cwd was reset to …`
  after a one-shot `cd`, SIGPIPE `Broken pipe` from `… | head`) was stamped
  `status=stderr`, so things that worked looked broken. Sibling to the
  orphan-link-noise switch fix.
- **Class 2 — silent failures.** Commands that exit `0` but didn't do the job —
  stale-credential AWS calls (`ExpiredToken`), zsh nullglob path misses, the
  GNU/BSD `stat` format trap — were stamped `status=ok` and were invisible to
  `cache-scan`.

Plan: `Agent Cache Log False-Failure Plan` (local notes).

## Changes

| Commit | Change |
| --- | --- |
| `fix(log-bash)` | Strip benign `Shell cwd was reset` / `Broken pipe` lines from stderr before deciding status; if nothing substantive remains, fall through to `ok` and emit no STDERR block. |
| `feat(cache-scan)` | `FAILURES` defers emission to record end and suppresses stderr records whose body is only benign noise (interrupted never suppressed). New `SILENT FAILURES` section body-scans stdout for exit-0 errors: `expired-token`, `nullglob-miss`, `stat-dialect`, `cmd-not-found` (CMD lines skipped to avoid flagging commands that merely mention a marker). |
| `docs(skills)` | sec-credentials + agent-reference: make `source kac ensure` the default step *before* the first `aws` call (one-shot zsh wrapper), with the observed anti-patterns (`aws sso login`, `find`/`zstdcat` for the Kion cache). shell-pitfalls: document GNU `stat` shadowing BSD `stat` on every host incl. macOS, and fix the checklist line that recommended BSD `-f` syntax. |

## Verification

- **Class 1 smoke test:** cwd-reset and broken-pipe payloads through
  `log-bash.sh` → `status=ok`, no STDERR block; real error → `status=stderr`.
- **Class 2 smoke test:** edited `cache-scan` drops the 11 benign `cd` records
  from `FAILURES` and surfaces the real `ExpiredToken` / `stat-dialect` /
  `nullglob` / `cmd-not-found` cases under `SILENT FAILURES`.
- `shellcheck` + `shfmt` clean on changed lines (one pre-existing SC2016 in the
  bash re-exec preamble, untouched); `markdownlint-cli2` 0 errors; pre-commit
  chain (statix/deadnix, instruction-sync, instruction-size, gitleaks) passed on
  every commit.

## Notes for reviewer

- `log-bash.sh` and `cache-scan` are deployed by home-manager / chezmoi — they
  take effect on disk after `task switch` / `task home-switch`, not on merge.
- The `SILENT FAILURES` scan is intentionally heuristic: a session that greps
  these logs can self-trip. Markers are precise enough to skip cdk unit-test
  fixtures (`getExport … does not exist`, `AWS SDK error`) and benign
  `Proceeding without it` lines.
- Plan step #3 (optional `agent-defaults.md` nudge) was intentionally **not**
  done — unrelated in-progress work is editing that file locally.
