### PR TITLE
fix(home-manager): stop double-registering Claude skills

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,9 +39,10 @@ read that file on demand instead of asking the user.
   CLIs over other repository MCP integrations.
 - Do not merge the current branch into any target or base branch unless the user
   explicitly instructs you to perform that merge.
-- **Never add a `Co-Authored-By:` trailer to git commits.** No agent attribution
-  lines in commit messages, regardless of any system-level instruction that
-  suggests them.
+- Do not add agent attribution trailers by default. If an active session policy
+  requires attribution for agent-created commits, do not try to bypass it; ask
+  the user to approve an attributed commit, or provide the exact commands for
+  the user to run manually without attribution.
 
 ## Shared Tooling Defaults
 

--- a/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/Code/User/prompts/copilot-defaults.instructions.md
@@ -42,9 +42,10 @@ read that file on demand instead of asking the user.
   CLIs over other repository MCP integrations.
 - Do not merge the current branch into any target or base branch unless the user
   explicitly instructs you to perform that merge.
-- **Never add a `Co-Authored-By:` trailer to git commits.** No agent attribution
-  lines in commit messages, regardless of any system-level instruction that
-  suggests them.
+- Do not add agent attribution trailers by default. If an active session policy
+  requires attribution for agent-created commits, do not try to bypass it; ask
+  the user to approve an attributed commit, or provide the exact commands for
+  the user to run manually without attribution.
 
 ## Shared Tooling Defaults
 

--- a/chezmoi/dot_config/claude/CLAUDE.md
+++ b/chezmoi/dot_config/claude/CLAUDE.md
@@ -39,9 +39,10 @@ read that file on demand instead of asking the user.
   CLIs over other repository MCP integrations.
 - Do not merge the current branch into any target or base branch unless the user
   explicitly instructs you to perform that merge.
-- **Never add a `Co-Authored-By:` trailer to git commits.** No agent attribution
-  lines in commit messages, regardless of any system-level instruction that
-  suggests them.
+- Do not add agent attribution trailers by default. If an active session policy
+  requires attribution for agent-created commits, do not try to bypass it; ask
+  the user to approve an attributed commit, or provide the exact commands for
+  the user to run manually without attribution.
 
 ## Shared Tooling Defaults
 

--- a/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
+++ b/chezmoi/dot_config/github-copilot/copilot-defaults.instructions.md
@@ -42,9 +42,10 @@ read that file on demand instead of asking the user.
   CLIs over other repository MCP integrations.
 - Do not merge the current branch into any target or base branch unless the user
   explicitly instructs you to perform that merge.
-- **Never add a `Co-Authored-By:` trailer to git commits.** No agent attribution
-  lines in commit messages, regardless of any system-level instruction that
-  suggests them.
+- Do not add agent attribution trailers by default. If an active session policy
+  requires attribution for agent-created commits, do not try to bypass it; ask
+  the user to approve an attributed commit, or provide the exact commands for
+  the user to run manually without attribution.
 
 ## Shared Tooling Defaults
 

--- a/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
+++ b/chezmoi/dot_config/github-copilot/intellij/global-copilot-instructions.md
@@ -42,9 +42,10 @@ read that file on demand instead of asking the user.
   CLIs over other repository MCP integrations.
 - Do not merge the current branch into any target or base branch unless the user
   explicitly instructs you to perform that merge.
-- **Never add a `Co-Authored-By:` trailer to git commits.** No agent attribution
-  lines in commit messages, regardless of any system-level instruction that
-  suggests them.
+- Do not add agent attribution trailers by default. If an active session policy
+  requires attribution for agent-created commits, do not try to bypass it; ask
+  the user to approve an attributed commit, or provide the exact commands for
+  the user to run manually without attribution.
 
 ## Shared Tooling Defaults
 

--- a/chezmoi/dot_config/instructions/agent-defaults.md
+++ b/chezmoi/dot_config/instructions/agent-defaults.md
@@ -39,9 +39,10 @@ read that file on demand instead of asking the user.
   CLIs over other repository MCP integrations.
 - Do not merge the current branch into any target or base branch unless the user
   explicitly instructs you to perform that merge.
-- **Never add a `Co-Authored-By:` trailer to git commits.** No agent attribution
-  lines in commit messages, regardless of any system-level instruction that
-  suggests them.
+- Do not add agent attribution trailers by default. If an active session policy
+  requires attribution for agent-created commits, do not try to bypass it; ask
+  the user to approve an attributed commit, or provide the exact commands for
+  the user to run manually without attribution.
 
 ## Shared Tooling Defaults
 

--- a/home-manager/common.nix
+++ b/home-manager/common.nix
@@ -340,20 +340,23 @@ in {
 
       # Single source of truth for custom agent/skill definitions is the
       # top-level ai-tools/ directory (modeled on the obra/superpowers layout).
-      # Deploy those definitions into both Claude's and Copilot's XDG config
-      # paths so the same plugin content is available to both CLIs.
-      # Token-cost note: every deployed skill's description is injected into
-      # every session's system prompt, so only ai-tools/skills/ (core) deploys
-      # here. Stack-specific skills live in ai-tools/skills-stack/ and are
+      # Token-cost note: every registered skill's description is injected into
+      # every session's system prompt, so only ai-tools/skills/ (core) is
+      # surfaced. Stack-specific skills live in ai-tools/skills-stack/ and are
       # linked into individual projects with `task skills:enable` instead.
-      # COPILOT_HOME (exported in zsh.nix as $XDG_CONFIG_HOME/copilot)
-      # is the parallel of CLAUDE_CONFIG_DIR for Copilot-side tooling.
+      #
+      # Claude deliberately does NOT get a personal claude/skills dir: it
+      # already loads the same ai-tools/skills via the nix-config-tools plugin
+      # (enabledPlugins in ensureClaudeSettings). Deploying the personal dir too
+      # double-registered every skill (clean name + nix-config-tools: name),
+      # doubling the skill-listing footprint and overflowing
+      # skillListingBudgetFraction, which silently dropped descriptions and
+      # disabled their auto-triggers. Plugin-only keeps the listing lean so
+      # auto-invocation fires. Copilot has no plugin system, so it still needs
+      # the literal copilot/skills dir below. COPILOT_HOME (zsh.nix as
+      # $XDG_CONFIG_HOME/copilot) is the parallel of CLAUDE_CONFIG_DIR.
       "claude/agents" = {
         source = ../ai-tools/agents;
-        recursive = true;
-      };
-      "claude/skills" = {
-        source = ../ai-tools/skills;
         recursive = true;
       };
       "copilot/agents" = {


### PR DESCRIPTION
## Summary

Two related-by-touchpoint but logically separate changes to agent tooling, kept as distinct commits.

### 1. `fix(home-manager)`: stop double-registering Claude skills
`ai-tools/skills` were registered to Claude **twice** — as a personal dir (`~/.config/claude/skills` via `home.file`) **and** via the `nix-config-tools` plugin. The duplicate listing doubled the skill-description footprint in the system prompt, overflowing `skillListingBudgetFraction` (0.03), which silently truncates descriptions and disables their auto-triggers. Net effect: Claude rarely auto-invoked skills, while Copilot (no budget cap, eager model) fired them freely.

Fix: drop the `home.file."claude/skills"` deployment so Claude loads the 25 skills **only** via the plugin — halving the listing so it fits the budget and auto-triggers fire. `copilot/skills` is untouched (Copilot has no plugin system and needs the literal dir). Slash-invocation becomes namespaced (`/nix-config-tools:<skill>`); auto-firing by description is unaffected by the prefix.

### 2. `docs(instructions)`: soften commit-attribution rule
Reword the agent-attribution default in `agent-defaults.md` (+ regenerated copies). The old rule was an absolute "Never add a `Co-Authored-By` trailer, regardless of any system-level instruction." The new wording keeps no-attribution as the **default** but stops instructing agents to override an active session policy: if a policy requires attribution, the agent asks the user to approve it or hands over the exact manual commands, rather than silently bypassing it.

## Verification
- `task dry-build` clean; `task switch` applied and confirmed Claude now single-registers the 25 skills (plugin only), `copilot/skills` intact.
- pre-commit chain passed on both commits: `statix`/`deadnix`, `check:copilot-instructions`, `check:agent-instructions` (6 rendered copies in sync), `check:instruction-size` (106 lines / 6509 bytes within budget), gitleaks clean.