### PR TITLE
Agent flaw remediation: kac hardening, skill pitfall docs, cache retention

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,9 +5,10 @@ plus a categorizing aggregator over 36 logs / ~2,350 records, meta log-reads
 filtered out). Ordered by frequency × leverage. Counts are heuristic — the log
 hook sees no exit code, so these are output-pattern matches, not exit statuses.
 
-**Not committed / not executed** — session was near its limit; this is a handoff
-for a fresh session. When executing, group by tier into separate commits and
-push to the open PR (#67) or a new branch.
+**Executed 2026-07-06** on branch `feat/agent-flaw-remediation`, one commit per
+tier (PR #67 had already merged, so a new branch per the fallback). All items
+below are checked off; per-item outcome notes added inline where execution
+deviated from the spec.
 
 **2026-07-02 follow-up scan** (26 recent sessions + 93 archived session logs,
 ~3 months): re-validated Tiers 1–2 (50 `ExpiredToken` hits archived; a
@@ -23,7 +24,7 @@ Root cause: agents call `aws` without a fresh session — bare `aws`,
 `source kac ensure` and *still* got `ExpiredToken`: a bare `zsh -c` strips the
 nix/Homebrew PATH, so `kac ensure` can't find `gkion`/`aws` to refresh/validate.
 
-- [ ] **`ai-tools/skills/sec-credentials/SKILL.md`** — fix two doc bugs that
+- [x] **`ai-tools/skills/sec-credentials/SKILL.md`** — fix two doc bugs that
       actively cause the stale-creds pattern:
   - Line ~37: drop "must be sourced, **zsh only**" — `kac` now sources under bash
     too (fixed in commit ba95641). Say "source it from bash or zsh".
@@ -40,7 +41,7 @@ nix/Homebrew PATH, so `kac ensure` can't find `gkion`/`aws` to refresh/validate.
   - Warn: a bare `zsh -c '…'` (no `-l`) strips the nix profile + `/opt/homebrew`
     PATH, so `gkion`/`aws` "vanish" and the refresh silently fails. Use the
     current (already-provisioned) shell, or `zsh -lc`, or pass PATH explicitly.
-- [ ] **`chezmoi/dot_local/lib/kion-aws-cache`** — harden `_kion_aws_cache_main`:
+- [x] **`chezmoi/dot_local/lib/kion-aws-cache`** — harden `_kion_aws_cache_main`:
       prepend the known tool dirs to a **`local PATH`** so a PATH-stripped
       subshell can still validate + refresh. Scope with `local` so the caller's
       PATH is untouched; exported `AWS_*` still persist. Dirs to add if present:
@@ -48,7 +49,7 @@ nix/Homebrew PATH, so `kac ensure` can't find `gkion`/`aws` to refresh/validate.
       `/run/current-system/sw/bin`, `$HOME/.nix-profile/bin` (aws). This fixes
       the "sourced kac but still ExpiredToken" case. Re-`shfmt`, re-test both
       shells (see Verify).
-- [ ] **`ai-tools/skills/shell-pitfalls/SKILL.md`** (and cross-link
+- [x] **`ai-tools/skills/shell-pitfalls/SKILL.md`** (and cross-link
       `gh-graphql-jq-pipelines`) — the "Heavy quoting → write a script file"
       section: add an **AWS-logs / jq** example (nested quotes + `$LATEST` /
       glob tokens, e.g. `aws logs filter-log-events … '2026/06/30/[$LATEST]…'`).
@@ -56,18 +57,18 @@ nix/Homebrew PATH, so `kac ensure` can't find `gkion`/`aws` to refresh/validate.
 
 ## Tier 2 — recurring shell traps
 
-- [ ] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — NEW section **"Subshell
+- [x] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — NEW section **"Subshell
       PATH loss"**: `env -i`, `sudo`, and bare `zsh -c` do **not** inherit the
       nix profile PATH, so `stat`/`timeout`/`gkion`/`aws` appear "not found" even
       though they're on the interactive PATH (verified: GNU `stat -c`, `timeout`
       both resolve in a login shell). Fix: pass `PATH=` explicitly or use
       absolute paths. Ties Tier-1's kac failure to a general rule.
       (stat-dialect 4 + cmd-not-found 6 hits.)
-- [ ] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — promote zsh **`nullglob`**
+- [x] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — promote zsh **`nullglob`**
       "no matches found" to a first-class section (4 hits: `docker-compose*.yml`,
       `~/.config/ops-agent/config*` with no match abort the command). Fix: quote
       the glob, guard with `2>/dev/null`, or use `fd`.
-- [ ] **`chezmoi/dot_config/instructions/agent-reference.md`** — tool catalog:
+- [x] **`chezmoi/dot_config/instructions/agent-reference.md`** — tool catalog:
       `psql` is **NOT installed** on managed hosts (use `docker exec <db> psql`
       or add it); `nc` is BSD (`/usr/bin/nc`, different flags); note GNU
       coreutils + `timeout` are only on the login PATH (see Subshell PATH loss).
@@ -76,14 +77,14 @@ nix/Homebrew PATH, so `kac ensure` can't find `gkion`/`aws` to refresh/validate.
 
 ## Tier 3 — lower / external
 
-- [ ] **`ai-tools/skills/ops-jira-integration/SKILL.md`** — note: Jira API
+- [x] **`ai-tools/skills/ops-jira-integration/SKILL.md`** — note: Jira API
       `Connection reset by peer` on VPN (4 hits) → retry with backoff; prefer
       direct REST with the token (already the standing rule).
-- [ ] **Darwin cask permission/TCC** — document the Full Disk Access grant for
+- [x] **Darwin cask permission/TCC** — document the Full Disk Access grant for
       root-owned / TCC-protected `/Applications` casks (`sudo chown`/`rm -rf
       …Caskroom`). Ties to the `project_switch_nonfatal_errors` memory and the
       switch-tolerance work in PR #67. Put in `agent-reference.md` or ops notes.
-- [ ] TS/build failures (36, mostly real dev iteration: `./run typecheck`,
+- [x] TS/build failures (36, mostly real dev iteration: `./run typecheck`,
       `tsc -b`) live in the **mdp-application** repo, not here — no change in
       this repo. Optional: note "standardize on `./run typecheck`" there.
 
@@ -93,11 +94,11 @@ The cache dir is now an AI liability: 460 MB, 5,254 top-level entries, 3,976 of
 them archived one-off `.log` files. `cache-scan`, credential/disk lookups, and
 any `rg`/`fd` sweep over `~/.cache/copilot` wade through all of it.
 
-- [ ] **`ai-tools/scripts/compress-old-cache`** — add a **retention pass**:
+- [x] **`ai-tools/scripts/compress-old-cache`** — add a **retention pass**:
       delete `.zst` archives older than **1.5 years** (`fd --max-depth 1
       --type f -e zst --changed-before 78weeks … | xargs -0 rm`). Keep the
       existing live-session grace; keep the 30-min throttle.
-- [ ] **`ai-tools/scripts/compress-old-cache`** — handle **subdirectories**:
+- [x] **`ai-tools/scripts/compress-old-cache`** — handle **subdirectories**:
       the current `fd --max-depth 1 --type f` never compresses or prunes
       subdirs, so big trees sit uncompressed forever (129 MB
       `mdpmdd-827-diagram/` incl. `node_modules`, 110 MB `vscode-stable-clean/`,
@@ -105,42 +106,44 @@ any `rg`/`fd` sweep over `~/.cache/copilot` wade through all of it.
       subdirectories by mtime (`rm -rf` after the threshold); always exclude
       `node_modules` trees from any compression sweep (delete-only). Document
       the policy in the script header and the ops-cache-scan skill.
-- [ ] **Graduate `failscan.py`** — the failure-categorizing aggregator cited in
+- [x] **Graduate `failscan.py`** — the failure-categorizing aggregator cited in
       Evidence below lives only in a session scratchpad
       (`/private/tmp/claude-502/-Users-42245--config-nix/5dd8988a-…/scratchpad/failscan.py`)
       and `/private/tmp` does not survive reboots. A safety copy exists at
       `~/.cache/claude/failscan-rescued-20260702.py`. Fold it into
       `cache-scan` as a `--classify` mode (or `ai-tools/scripts/`) so failure
       triage is repeatable, then update the Evidence footnote here.
-- [ ] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — NEW pitfall: **piping
+- [x] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — NEW pitfall: **piping
       non-JSON into `jq`**. 8+ archived hits of `jq: parse error: Invalid
       numeric literal` from feeding an HTML 401/error page into `jq`, plus a
       `null` result used as a file path (`bash: null: No such file or
       directory`). Fix: `curl -fsS` (fail on HTTP errors), check the payload
       before filtering, use `// empty` defaults, and `gron` for unknown-shaped
       JSON.
-- [ ] **Per-ticket helper graduation** (optional) — `~/.cache/copilot/`
+- [x] **Per-ticket helper graduation** (optional) — `~/.cache/copilot/`
       `mdpmdd800-bench/{rds-exec.sh,jira-comment.py,queries*.sh}` get rewritten
-      each session. `jira-comment.py` is likely obsolete (ops-agent posts Jira
-      comments); assess `rds-exec.sh` for promotion to `~/.local/bin` via
-      chezmoi.
+      each session. *Assessed 2026-07-06, no promotion:* `jira-comment.py` is a
+      one-shot with a hardcoded MDPMDD-800 body — obsolete (ops-agent posts
+      Jira comments); `rds-exec.sh` hardcodes the dev6 cluster + secret ARNs —
+      a parameterized Data-API helper would belong in mdp-application, not this
+      repo.
 
 ## Verify (after executing)
 
-- [ ] `kac` still sources clean in **both** shells:
+- [x] `kac` still sources clean in **both** shells:
       `bash -c 'source chezmoi/dot_local/bin/executable_kac status'` and the same
       under `zsh -c` (expect `current=…`, exit 0). Test `ensure` reaches `gkion`
       from a stripped subshell: `env -i HOME="$HOME" bash -c 'source …/kac status'`.
-- [ ] `shfmt -d chezmoi/dot_local/lib/kion-aws-cache` clean; `task lint:sh` green.
-- [ ] `markdownlint-cli2` clean on every edited SKILL.md (note: `lint:md` skips
+- [x] `shfmt -d chezmoi/dot_local/lib/kion-aws-cache` clean; `task lint:sh` green.
+- [x] `markdownlint-cli2` clean on every edited SKILL.md (note: `lint:md` skips
       `ai-tools/`, so lint the skill files directly).
-- [ ] No always-on prefix (`agent-defaults.md`) change → no
+- [x] No always-on prefix (`agent-defaults.md`) change → no
       `task generate:agent-instructions` needed. If that changes, regenerate.
-- [ ] `compress-old-cache` retention: dry-run first (swap `rm` for `echo` /
+- [x] `compress-old-cache` retention: dry-run first (swap `rm` for `echo` /
       `fd … --changed-before 78weeks` listing) and eyeball the candidate list
       before the first destructive run; `shfmt -d ai-tools/scripts/compress-old-cache`
       clean; confirm the live `session_*.log` and recent artifacts survive.
-- [ ] `cache-scan --classify` (or the graduated aggregator) reproduces the
+- [x] `cache-scan --classify` (or the graduated aggregator) reproduces the
       Evidence categories below on the current logs.
 
 ## Evidence (category → count, 21-day window, de-noised)
@@ -148,5 +151,6 @@ any `rg`/`fd` sweep over `~/.cache/copilot` wade through all of it.
 `stale-aws-creds 20 · build-ts-node 36 (mostly real dev) · file-not-found 18 ·
 cmd-not-found 6 · gh-graphql-jq 5 · quoting-heredoc 5 · permission-denied 5 ·
 zsh-nullglob 4 · stat-dialect 4 · network-tls 4 · git-workflow 1 · nix-build 1`.
-Aggregator: `scratchpad/failscan.py` (session-local; re-derive with
-`cache-scan --days 21` for the structured FAILURES/SILENT-FAILURES view).
+Aggregator: graduated into `cache-scan --classify` (safety copy of the
+original at `~/.cache/claude/failscan-rescued-20260702.py` can be deleted once
+the chezmoi-deployed cache-scan is confirmed on all hosts).

--- a/TODO.md
+++ b/TODO.md
@@ -1,74 +1,152 @@
-# TODO
+# TODO — skill & tool-use flaw remediation
 
-## cache-scan native-transcript enrichment (`-t|--transcript`)
+Execution-ready plan from a 3-week cache-log failure scan (`cache-scan --days 21`
+plus a categorizing aggregator over 36 logs / ~2,350 records, meta log-reads
+filtered out). Ordered by frequency × leverage. Counts are heuristic — the log
+hook sees no exit code, so these are output-pattern matches, not exit statuses.
 
-### Goal
+**Not committed / not executed** — session was near its limit; this is a handoff
+for a fresh session. When executing, group by tier into separate commits and
+push to the open PR (#67) or a new branch.
 
-Let `cache-scan` recover *intent*, not just commands. The Bash `PostToolUse` log
-(`~/.cache/<agent>/session_<id>.log`) records only `CMD/STDOUT/STDERR`. Claude
-Code already writes the rest to disk for free — the full session transcript and
-the prompt-input log — so the reader can join and surface it with no model calls
-and no credits.
+**2026-07-02 follow-up scan** (26 recent sessions + 93 archived session logs,
+~3 months): re-validated Tiers 1–2 (50 `ExpiredToken` hits archived; a
+stale-creds `kac load` in that day's session), confirmed the stat-dialect fix
+landed in shell-pitfalls, and added Tier 4 (cache hygiene + artifact
+graduation) plus the `kac load` bullet in Tier 1.
 
-### Free native sources joined by session id
+## Tier 1 — systemic (AWS credentials dominate: 20 of the failures)
 
-| Signal | Source (read-only, no credits) |
-| --- | --- |
-| Your typed prompts | `~/.config/claude/history.jsonl` (keyed by `sessionId`) |
-| Assistant decision text | `~/.config/claude/projects/*/<id>.jsonl` (`type==assistant` → `content[].text`) |
-| Files Edit/Write changed | transcript `tool_use` in `Edit`/`Write`/`NotebookEdit` → `input.file_path` |
-| Non-Bash tool tally | transcript `tool_use` where `name != Bash` |
-| Older runs | `~/.claude/projects/*/<id>.jsonl` (pre-XDG location) |
+Root cause: agents call `aws` without a fresh session — bare `aws`,
+`AWS_PROFILE=… aws` (stale), or `export …=$(cat ~/.cache/kion-aws-cache/…)`
+(stale) — instead of `source ~/.local/bin/kac ensure` first. One case ran
+`source kac ensure` and *still* got `ExpiredToken`: a bare `zsh -c` strips the
+nix/Homebrew PATH, so `kac ensure` can't find `gkion`/`aws` to refresh/validate.
 
-Join key: cache log `session_<id>.log` ⇄ `history.jsonl.sessionId` ⇄ transcript
-filename `<id>.jsonl`. All three use the same session UUID.
+- [ ] **`ai-tools/skills/sec-credentials/SKILL.md`** — fix two doc bugs that
+      actively cause the stale-creds pattern:
+  - Line ~37: drop "must be sourced, **zsh only**" — `kac` now sources under bash
+    too (fixed in commit ba95641). Say "source it from bash or zsh".
+  - Lines ~60-66: remove or hard-caveat the "If you can't source `kac`, read the
+    cached values directly" `cat …/AWS_*` block — raw `cat` gives **no freshness
+    guarantee** and is the exact observed anti-pattern (loads stale creds).
+  - Require checking `kac ensure`'s **exit code**; never run `aws` if it failed
+    (`source ~/.local/bin/kac ensure && aws …`).
+  - Document `load` vs `ensure`: `kac load` validates cached creds but **does
+    not refresh** — on expiry it fails (`&&` chain stops) instead of
+    self-healing via gkion, sending agents off exploring (observed 2026-07-02:
+    `source ~/.local/bin/kac load && …`). Rule: agents always use `ensure`;
+    have `load`'s expiry message point at `ensure`.
+  - Warn: a bare `zsh -c '…'` (no `-l`) strips the nix profile + `/opt/homebrew`
+    PATH, so `gkion`/`aws` "vanish" and the refresh silently fails. Use the
+    current (already-provisioned) shell, or `zsh -lc`, or pass PATH explicitly.
+- [ ] **`chezmoi/dot_local/lib/kion-aws-cache`** — harden `_kion_aws_cache_main`:
+      prepend the known tool dirs to a **`local PATH`** so a PATH-stripped
+      subshell can still validate + refresh. Scope with `local` so the caller's
+      PATH is untouched; exported `AWS_*` still persist. Dirs to add if present:
+      `/opt/homebrew/bin` (gkion), `/etc/profiles/per-user/$USER/bin`,
+      `/run/current-system/sw/bin`, `$HOME/.nix-profile/bin` (aws). This fixes
+      the "sourced kac but still ExpiredToken" case. Re-`shfmt`, re-test both
+      shells (see Verify).
+- [ ] **`ai-tools/skills/shell-pitfalls/SKILL.md`** (and cross-link
+      `gh-graphql-jq-pipelines`) — the "Heavy quoting → write a script file"
+      section: add an **AWS-logs / jq** example (nested quotes + `$LATEST` /
+      glob tokens, e.g. `aws logs filter-log-events … '2026/06/30/[$LATEST]…'`).
+      5 hits, all `source kac ensure >/dev/null` + heavy-quoted `aws logs …`.
 
-### Done (drafted + tested in this branch)
+## Tier 2 — recurring shell traps
 
-- [x] `chezmoi/dot_local/bin/executable_cache-scan`: add `-t|--transcript` flag,
-      `find_transcript`, `distill_session`, `base_id` (normalizes
-      `.skills`/`.thinking` companion logs + dedupes), and a
-      `NATIVE TRANSCRIPT ENRICHMENT` section emitting PROMPTS / DECISIONS /
-      FILE EDITS / NON-BASH TOOLS.
-- [x] `jq` guard (graceful skip), home-dir redaction on paths, terse output.
-- [x] `ai-tools/skills/ops-cache-scan/SKILL.md`: document the flag in Inputs,
-      Procedure, and What-To-Extract.
-- [x] Validated: `bash -n` parses; real session shows prompts + decisions +
-      edited files; default mode unchanged; Copilot-only session degrades
-      gracefully; `-t -v` exits 0.
-- [x] **Copilot parity**: `distill_copilot` reads
-      `~/.config/copilot/session-state/<id>/events.jsonl` — prompts
-      (`user.message`, `<skill-context>` noise filtered), decisions
-      (`assistant.message`), file edits (`apply_patch` V4A markers), tool tally
-      (`tool.execution_start.toolName`), and an `AGENT/MODEL` line. (Used
-      `events.jsonl` over `command-history-state.json` — keyed by session, full
-      prompt text.)
-- [x] **Operational context**: `OPERATIONAL` block surfaces the model and the
-      curated real error lines from the matching
-      `~/.config/copilot/logs/process-*.log` (benign ERROR-level lifecycle
-      noise filtered out).
-- [x] **File-edit diffs** (`--diffs`): reconstructs exact edits from the
-      transcript's verbatim `old_string`/`new_string` (Claude) and the
-      `apply_patch` V4A payloads (Copilot), capped by `--limit`. Sourced from
-      the transcript, **not** `~/.claude/file-history/<id>/<hash>@vN` — those
-      snapshots carry no hash→path manifest, so the transcript inputs are the
-      exact, keyed, free source.
-- [x] Dispatcher: `distill_session` tries the Claude transcript first, then the
-      Copilot event stream. SKILL.md updated for `--diffs` + Copilot parity.
+- [ ] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — NEW section **"Subshell
+      PATH loss"**: `env -i`, `sudo`, and bare `zsh -c` do **not** inherit the
+      nix profile PATH, so `stat`/`timeout`/`gkion`/`aws` appear "not found" even
+      though they're on the interactive PATH (verified: GNU `stat -c`, `timeout`
+      both resolve in a login shell). Fix: pass `PATH=` explicitly or use
+      absolute paths. Ties Tier-1's kac failure to a general rule.
+      (stat-dialect 4 + cmd-not-found 6 hits.)
+- [ ] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — promote zsh **`nullglob`**
+      "no matches found" to a first-class section (4 hits: `docker-compose*.yml`,
+      `~/.config/ops-agent/config*` with no match abort the command). Fix: quote
+      the glob, guard with `2>/dev/null`, or use `fd`.
+- [ ] **`chezmoi/dot_config/instructions/agent-reference.md`** — tool catalog:
+      `psql` is **NOT installed** on managed hosts (use `docker exec <db> psql`
+      or add it); `nc` is BSD (`/usr/bin/nc`, different flags); note GNU
+      coreutils + `timeout` are only on the login PATH (see Subshell PATH loss).
+      (`agent-reference.md` is read on-demand, NOT the always-on prefix — no
+      instruction regen needed.)
 
-### To ship
+## Tier 3 — lower / external
 
-- [ ] Deploy: `task switch` (runs `chezmoi apply`) so `~/.local/bin/cache-scan`
-      updates; confirm `cache-scan --session <id> -t` on a live host.
-- [ ] Lint: `task lint:md` (this file + SKILL.md), and `shfmt`/shellcheck on the
-      script if wired into the pre-commit chain.
-- [ ] Commit script + skill doc together; do not hand-edit the deployed copy.
+- [ ] **`ai-tools/skills/ops-jira-integration/SKILL.md`** — note: Jira API
+      `Connection reset by peer` on VPN (4 hits) → retry with backoff; prefer
+      direct REST with the token (already the standing rule).
+- [ ] **Darwin cask permission/TCC** — document the Full Disk Access grant for
+      root-owned / TCC-protected `/Applications` casks (`sudo chown`/`rm -rf
+      …Caskroom`). Ties to the `project_switch_nonfatal_errors` memory and the
+      switch-tolerance work in PR #67. Put in `agent-reference.md` or ops notes.
+- [ ] TS/build failures (36, mostly real dev iteration: `./run typecheck`,
+      `tsc -b`) live in the **mdp-application** repo, not here — no change in
+      this repo. Optional: note "standardize on `./run typecheck`" there.
 
-### Decided against (not free, or not worth the tokens)
+## Tier 4 — cache hygiene & artifact graduation (2026-07-02 scan)
 
-- Telemetry (`~/.claude/telemetry/1p_failed_events.*.json`): diagnostic only,
-  no cost/token data — skipped.
-- Thinking text: signature-only in transcripts too — nothing to redirect.
+The cache dir is now an AI liability: 460 MB, 5,254 top-level entries, 3,976 of
+them archived one-off `.log` files. `cache-scan`, credential/disk lookups, and
+any `rg`/`fd` sweep over `~/.cache/copilot` wade through all of it.
 
-> Prior TODO backlog (tool-skill additions, tool ingestion) was truncated per
-> request; recover it with `git show HEAD:TODO.md` if needed.
+- [ ] **`ai-tools/scripts/compress-old-cache`** — add a **retention pass**:
+      delete `.zst` archives older than **1.5 years** (`fd --max-depth 1
+      --type f -e zst --changed-before 78weeks … | xargs -0 rm`). Keep the
+      existing live-session grace; keep the 30-min throttle.
+- [ ] **`ai-tools/scripts/compress-old-cache`** — handle **subdirectories**:
+      the current `fd --max-depth 1 --type f` never compresses or prunes
+      subdirs, so big trees sit uncompressed forever (129 MB
+      `mdpmdd-827-diagram/` incl. `node_modules`, 110 MB `vscode-stable-clean/`,
+      44 MB CI run artifacts). Apply the same 1.5-year retention to
+      subdirectories by mtime (`rm -rf` after the threshold); always exclude
+      `node_modules` trees from any compression sweep (delete-only). Document
+      the policy in the script header and the ops-cache-scan skill.
+- [ ] **Graduate `failscan.py`** — the failure-categorizing aggregator cited in
+      Evidence below lives only in a session scratchpad
+      (`/private/tmp/claude-502/-Users-42245--config-nix/5dd8988a-…/scratchpad/failscan.py`)
+      and `/private/tmp` does not survive reboots. A safety copy exists at
+      `~/.cache/claude/failscan-rescued-20260702.py`. Fold it into
+      `cache-scan` as a `--classify` mode (or `ai-tools/scripts/`) so failure
+      triage is repeatable, then update the Evidence footnote here.
+- [ ] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — NEW pitfall: **piping
+      non-JSON into `jq`**. 8+ archived hits of `jq: parse error: Invalid
+      numeric literal` from feeding an HTML 401/error page into `jq`, plus a
+      `null` result used as a file path (`bash: null: No such file or
+      directory`). Fix: `curl -fsS` (fail on HTTP errors), check the payload
+      before filtering, use `// empty` defaults, and `gron` for unknown-shaped
+      JSON.
+- [ ] **Per-ticket helper graduation** (optional) — `~/.cache/copilot/`
+      `mdpmdd800-bench/{rds-exec.sh,jira-comment.py,queries*.sh}` get rewritten
+      each session. `jira-comment.py` is likely obsolete (ops-agent posts Jira
+      comments); assess `rds-exec.sh` for promotion to `~/.local/bin` via
+      chezmoi.
+
+## Verify (after executing)
+
+- [ ] `kac` still sources clean in **both** shells:
+      `bash -c 'source chezmoi/dot_local/bin/executable_kac status'` and the same
+      under `zsh -c` (expect `current=…`, exit 0). Test `ensure` reaches `gkion`
+      from a stripped subshell: `env -i HOME="$HOME" bash -c 'source …/kac status'`.
+- [ ] `shfmt -d chezmoi/dot_local/lib/kion-aws-cache` clean; `task lint:sh` green.
+- [ ] `markdownlint-cli2` clean on every edited SKILL.md (note: `lint:md` skips
+      `ai-tools/`, so lint the skill files directly).
+- [ ] No always-on prefix (`agent-defaults.md`) change → no
+      `task generate:agent-instructions` needed. If that changes, regenerate.
+- [ ] `compress-old-cache` retention: dry-run first (swap `rm` for `echo` /
+      `fd … --changed-before 78weeks` listing) and eyeball the candidate list
+      before the first destructive run; `shfmt -d ai-tools/scripts/compress-old-cache`
+      clean; confirm the live `session_*.log` and recent artifacts survive.
+- [ ] `cache-scan --classify` (or the graduated aggregator) reproduces the
+      Evidence categories below on the current logs.
+
+## Evidence (category → count, 21-day window, de-noised)
+
+`stale-aws-creds 20 · build-ts-node 36 (mostly real dev) · file-not-found 18 ·
+cmd-not-found 6 · gh-graphql-jq 5 · quoting-heredoc 5 · permission-denied 5 ·
+zsh-nullglob 4 · stat-dialect 4 · network-tls 4 · git-workflow 1 · nix-build 1`.
+Aggregator: `scratchpad/failscan.py` (session-local; re-derive with
+`cache-scan --days 21` for the structured FAILURES/SILENT-FAILURES view).

--- a/ai-tools/scripts/compress-old-cache
+++ b/ai-tools/scripts/compress-old-cache
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
-# Compress cache files with zstd once they are older than 1 day, plus any file
-# already exceeding 1 MB (with a short modification grace so the live session
-# log is never compressed mid-write).
-# Invoked by agent hooks; supports both Claude and Copilot caches.
-# Files already ending in .zst are skipped; originals are removed on success.
+# Cache maintenance, invoked by agent hooks for both Claude and Copilot caches.
+# Two passes:
+#   1. Compress: zstd top-level files older than 1 day, plus any file already
+#      exceeding 1 MB (with a short modification grace so the live session log
+#      is never compressed mid-write). .zst files are skipped; originals are
+#      removed on success.
+#   2. Retention: the cache is an investigation surface, not an archive.
+#      Delete top-level .zst archives untouched for CACHE_RETENTION_DAYS
+#      (default 548 ≈ 1.5 years) and prune subdirectories in which nothing was
+#      modified within that window (session working dirs, extracted CI
+#      artifacts, node_modules trees — subdirectories are never compressed,
+#      only removed by this pass). COMPRESS_OLD_CACHE_DRY_RUN=1 prints the
+#      retention candidates instead of deleting them.
 set -euo pipefail
 
 # Resolve agent/cache target.
@@ -42,5 +50,35 @@ fi
 	[[ -e "${file_path}.zst" ]] && continue
 	printf '%s\0' "$file_path"
 done | xargs -0 -r zstd -q --rm --
+
+# --- Retention pass -------------------------------------------------------
+retention_days="${CACHE_RETENTION_DAYS:-548}"
+[[ "$retention_days" =~ ^[0-9]+$ ]] || retention_days=548
+dry_run="${COMPRESS_OLD_CACHE_DRY_RUN:-0}"
+
+remove() {
+	if [[ "$dry_run" != "0" ]]; then
+		printf 'retention would remove: %s\n' "$1"
+	else
+		rm -rf -- "$1"
+	fi
+}
+
+# Expired top-level archives.
+while IFS= read -r -d '' f; do
+	remove "$f"
+done < <(fd --max-depth 1 --type f -e zst \
+	--changed-before "${retention_days}d" . "$cache_dir" --print0)
+
+# Stale subdirectories: the dir entry itself must be past retention AND
+# nothing inside modified within the window (protects freshly created working
+# dirs whose content hasn't landed yet).
+while IFS= read -r -d '' dir; do
+	if [[ -z $(fd --type f --changed-within "${retention_days}d" \
+		. "$dir" --max-results 1 2>/dev/null) ]]; then
+		remove "$dir"
+	fi
+done < <(fd --max-depth 1 --type d \
+	--changed-before "${retention_days}d" . "$cache_dir" --print0)
 
 printf '%s\n' "$now_epoch" >"$stamp_file"

--- a/ai-tools/skills/ops-cache-scan/SKILL.md
+++ b/ai-tools/skills/ops-cache-scan/SKILL.md
@@ -19,6 +19,8 @@ STDOUT: / STDERR: sections
 
 `status` is a heuristic (no exit code is exposed to the hook): `interrupted`, else `stderr` when stderr is non-empty, else `ok`. Activation also enforces `~/.cache/claude` → `~/.cache/copilot` as a symlink so both agents share one log dir.
 
+Lifecycle: `compress-old-cache` (hook + daily timer) zstd-compresses top-level cache files older than 1 day (or over 1 MB), then applies a **retention pass** — top-level `.zst` archives and subdirectories untouched for `CACHE_RETENTION_DAYS` (default 548 ≈ 1.5 years) are deleted. Subdirectories are never compressed, only pruned, so anything that must survive long-term does not belong in the cache dir.
+
 This is *not* something a session needs to wire up — if the host has had `home-manager switch` run successfully, the hook is already firing on every Bash call. This skill consumes that log stream; it does not produce it. The companion read-side workflow lives in [flow-systematic-debugging](../flow-systematic-debugging/SKILL.md) Phase 0.
 
 ## Inputs
@@ -41,6 +43,14 @@ This is *not* something a session needs to wire up — if the host has had `home
   from the transcript's verbatim `old_string`/`new_string`, Copilot from the
   `apply_patch` V4A payloads. Capped by `--limit`; behind its own flag because
   diffs are token-heavy.
+- `--classify` aggregate failure categories across the window (`--days`
+  defaults to 21 here), including the `.zst` archives: buckets each record's
+  output into named categories (`stale-aws-creds`, `stat-dialect`,
+  `zsh-nullglob`, `gh-graphql-jq`, `jq-non-json-input`, …) and prints counts
+  plus example commands. Use for trend triage ("what keeps failing?"), not
+  single-session debugging. Heuristic — the log has no exit codes, and a
+  session that sweeps these logs can still self-trip; treat counts as leads.
+  Needs `python3`.
 - `-v|--verbose` add the command timeline and keyword scan (default output is
   intentionally terse to keep token cost low — read the default first and only
   reach for `--verbose` when you need the full timeline).
@@ -54,6 +64,8 @@ This is *not* something a session needs to wire up — if the host has had `home
    `cache-scan --session 4e8838e2 --transcript`
 5. Reconstruct the exact edits made (Claude or Copilot):
    `cache-scan --session 4e8838e2 --diffs`
+6. Trend triage — what keeps failing across sessions:
+   `cache-scan --classify` (or `--classify --days 60` for a longer horizon)
 
 ## What To Extract
 
@@ -81,6 +93,9 @@ This is *not* something a session needs to wire up — if the host has had `home
 - **DIFFS** (`--diffs`) — the exact per-edit changes for the focused session;
   read these when you need to see *what* a prior run actually wrote, not just
   which files it touched.
+- **CLASSIFY** (`--classify`) — category counts + example commands across the
+  window. The input for remediation planning (which skill/doc/helper to fix),
+  not for debugging one failure.
 
 ## Output Contract
 

--- a/ai-tools/skills/ops-jira-integration/SKILL.md
+++ b/ai-tools/skills/ops-jira-integration/SKILL.md
@@ -349,6 +349,7 @@ Coverage: XX%
 | `404` on Confluence `/move` or `/api/v2/pages` | Cloud-only endpoints | Use `PUT /rest/api/content/{id}` with `ancestors` + version bump |
 | `spawn uvx ENOENT` | IDE cannot find `uvx` on PATH | Use full path (e.g., `~/.local/bin/uvx`) or set PATH in `~/.zprofile` |
 | Connection timeout | Network/VPN issue | Check VPN connection and firewall rules |
+| `Connection reset by peer` | VPN-path flakiness (transient; recurs in bursts) | Retry the same request 2-3x with short backoff (`sleep 2`, `sleep 5`) before re-diagnosing; prefer direct REST with the token over CLI wrappers (standing rule) |
 
 ## Best Practices
 

--- a/ai-tools/skills/sec-credentials/SKILL.md
+++ b/ai-tools/skills/sec-credentials/SKILL.md
@@ -34,19 +34,31 @@ Use this skill when a task needs a credential and you don't yet know where to fi
 **Do not trust `~/.aws/credentials` or `AWS_PROFILE`** — they are usually stale and produce `ExpiredTokenException`. The live AWS session lives in the Kion credential cache at `~/.cache/kion-aws-cache/`. Prefer the `kac` helper, which loads from that cache and auto-refreshes via `gkion` when it's empty or expired:
 
 ```bash
-# Preferred: load valid creds into the current shell (must be sourced, zsh only)
+# Preferred: load valid creds into the current shell (must be sourced; works
+# from bash or zsh)
 source ~/.local/bin/kac ensure
 ```
 
 **Run `kac ensure` *before* the first `aws` call, not as recovery after one
-fails.** Firing `aws` against an inherited stale token wastes round-trips on
-`ExpiredTokenException` and then sends agents off exploring. For a one-shot,
-non-interactive invocation, wrap both in one zsh command so the refresh always
-precedes the call:
+fails, and gate the call on its exit code.** Firing `aws` against an inherited
+stale token wastes round-trips on `ExpiredTokenException` and then sends agents
+off exploring. For a one-shot, non-interactive invocation, chain both with `&&`
+so the refresh always precedes the call and a failed refresh stops the chain:
 
 ```bash
 zsh -lc 'source ~/.local/bin/kac ensure >/dev/null && aws sts get-caller-identity --output text'
 ```
+
+**`ensure`, not `load`.** `kac load` validates the cached creds but does **not**
+refresh them — on expiry it fails (stopping an `&&` chain) instead of
+self-healing via `gkion`. `load` is for a human who just refreshed; agents and
+scripts always use `ensure`.
+
+**Shell PATH note:** a bare `zsh -c '…'` (no `-l`) or `env -i` strips the
+nix/Homebrew `PATH`, which used to make `gkion`/`aws` "vanish" mid-refresh. The
+`kac` lib now prepends the known tool dirs itself, but prefer the current
+(already-provisioned) shell or `zsh -lc` anyway — other tools in the same
+command line don't get that rescue (see shell-pitfalls "Subshell PATH loss").
 
 Anti-patterns (observed wasting time in real sessions):
 
@@ -56,14 +68,11 @@ Anti-patterns (observed wasting time in real sessions):
   `~/.cache/kion-aws-cache/`; the path is documented here and in
   `agent-reference.md`. Re-deriving it from cold burns tokens and risks a stale
   path.
-
-If you can't source `kac`, read the cached values directly:
-
-```bash
-export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
-export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
-export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
-```
+- **Do not `cat` the cache files into `export`s**
+  (`export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/…)`). Raw reads
+  carry **no freshness guarantee** — this is the exact observed stale-creds
+  pattern. `kac ensure` reads the same files *and* validates/refreshes them;
+  there is no situation where the raw `cat` is the better move.
 
 If an `aws` call fails with an expired-token error, the inherited env vars (`AWS_ACCESS_KEY_ID`, etc.) are likely overriding the cache — clear them and re-source `kac` rather than editing `~/.aws/credentials`. Full `kac` subcommand reference is in `agent-reference.md`.
 

--- a/ai-tools/skills/shell-pitfalls/SKILL.md
+++ b/ai-tools/skills/shell-pitfalls/SKILL.md
@@ -176,6 +176,29 @@ committed zsh scripts add `setopt nullglob` (or the `(N)` qualifier per-glob).
 Bash behaves differently (passes the literal pattern through), which is why a
 snippet tested in bash breaks under zsh.
 
+## Piping non-JSON into `jq`
+
+`jq: parse error: Invalid numeric literal` almost never means malformed JSON —
+it means the payload isn't JSON at all: an HTML 401/error page from an
+unauthenticated `curl`, a log line, or an empty body. A related trap: a filter
+that yields `null` gets substituted into a later command as the literal string
+`null` (`bash: null: No such file or directory`).
+
+```bash
+# Wrong: a 401 HTML page goes straight into jq
+curl -s "$JIRA_URL/rest/api/2/issue/KEY-1" | jq '.fields.status.name'
+
+# Right: fail on HTTP errors so jq only ever sees a real body
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  "$JIRA_URL/rest/api/2/issue/KEY-1" | jq -r '.fields.status.name // empty'
+```
+
+Rules: `curl -fsS` (fail on 4xx/5xx) whenever the output feeds `jq`; give
+lookups a `// empty` (or explicit default) so `null` never leaks into a path
+or argument; when the payload's shape is unknown, `gron` it first. If the
+`jq` filter itself is long or quote-nested, file-back it
+(gh-graphql-jq-pipelines).
+
 ## Wrapped-capture permission-denied retry
 
 Some IDE harnesses wrap shell invocations in a capture command that tightens the executing process's permissions. If a script that *should* be executable returns `permission denied` only when wrapped — but works on a manual run — try invoking it with an explicit `/bin/zsh -f`:

--- a/ai-tools/skills/shell-pitfalls/SKILL.md
+++ b/ai-tools/skills/shell-pitfalls/SKILL.md
@@ -75,6 +75,29 @@ chmod +x ~/.cache/claude/post.sh
 
 The file form is also re-runnable (the agent's PostToolUse hook captures the path and contents in the log) and edit-friendly when the API call needs adjusting.
 
+The other recurring offender is **`aws logs` + `jq` one-shots**: a CloudWatch
+log-stream name contains `[$LATEST]` (dollar + brackets — both shell-active),
+the filter pattern needs its own quotes, and the whole thing gets wrapped in
+`zsh -lc '… kac ensure >/dev/null && aws logs …'`. Every observed failure of
+this shape was quoting rot, not AWS. Same rule: put the `aws logs
+filter-log-events` invocation (and any `jq` filter) in a script file first.
+
+```bash
+# Wrong: [$LATEST] and the pattern fight three quoting layers deep
+zsh -lc "source ~/.local/bin/kac ensure >/dev/null && aws logs filter-log-events --log-group-name '/aws/lambda/foo' --log-stream-names '2026/06/30/[\$LATEST]abc' --filter-pattern '\"ERROR\"' | jq '.events[].message'"
+
+# Right: script file — single quoting layer, re-runnable, log-friendly
+cat > ~/.cache/claude/logscan.sh <<'SCRIPT'
+#!/usr/bin/env bash
+source ~/.local/bin/kac ensure >/dev/null || exit 1
+aws logs filter-log-events \
+  --log-group-name '/aws/lambda/foo' \
+  --log-stream-names '2026/06/30/[$LATEST]abc' \
+  --filter-pattern '"ERROR"' | jq '.events[].message'
+SCRIPT
+bash ~/.cache/claude/logscan.sh
+```
+
 This is the codified version of the heuristic in [chezmoi/dot_config/instructions/agent-defaults.md L27](../../../chezmoi/dot_config/instructions/agent-defaults.md). When you find yourself on the third inline retry, stop and write a script.
 
 For the specific case of `gh api graphql` calls and long/nested `jq` filters — the highest-frequency offender — file-backing is a hard precondition, not a third-retry fallback. See [gh-graphql-jq-pipelines](../gh-graphql-jq-pipelines/SKILL.md) for the sanctioned `.graphql` + `.jq` file shape and the four recurring failure signatures.

--- a/ai-tools/skills/shell-pitfalls/SKILL.md
+++ b/ai-tools/skills/shell-pitfalls/SKILL.md
@@ -125,6 +125,57 @@ If you need a portable mtime regardless of which `stat` wins, sidestep it:
 `eza -l --time-style=long-iso <file>` or `date -r <file>`. The repo's own
 scripts assume GNU `stat -c` for this reason (see `cache-scan`'s header note).
 
+## Subshell PATH loss
+
+`env -i`, `sudo`, and a bare `zsh -c '…'` (no `-l`) do **not** inherit the nix
+profile + Homebrew `PATH`. Tools that resolve fine interactively — GNU `stat`,
+`timeout`, `gkion`, `aws` — suddenly report `command not found`, and it looks
+like a missing install when it's a missing PATH.
+
+```bash
+# Wrong: bare zsh -c gets the system default PATH — timeout/aws are not on it
+zsh -c 'timeout 30 aws s3 ls'
+
+# Right: login shell pulls in the nix/Homebrew profile
+zsh -lc 'timeout 30 aws s3 ls'
+
+# Also right: stay in the current (already-provisioned) shell, or pass PATH /
+# absolute paths explicitly when a stripped environment is unavoidable
+env -i HOME="$HOME" PATH="$PATH" bash -c 'timeout 30 aws s3 ls'
+```
+
+The `kac` credential helper PATH-hardens its own refresh internally, but
+nothing else on your command line gets that rescue. If a "not found" error
+names a tool you know is installed, check *which shell* is resolving it before
+reinstalling anything. This is also why the GNU-vs-BSD `stat` trap (above)
+sometimes appears to flip: a stripped PATH can fall back to `/usr/bin/stat`
+(BSD) while the interactive shell resolves the nix GNU one.
+
+## zsh nullglob: "no matches found" aborts the command
+
+Unlike bash, zsh **errors out** when a glob matches nothing — the command never
+runs at all:
+
+```zsh
+# Aborts with "zsh: no matches found: docker-compose*.yml" if none exist
+ls docker-compose*.yml
+
+# Guard 1: (N) qualifier — expands to nothing instead of erroring
+ls docker-compose*.yml(N)
+
+# Guard 2: let fd do the matching (no shell glob involved)
+fd -g 'docker-compose*.yml' --max-depth 1
+
+# Guard 3: test existence before globbing in scripts
+for f in docker-compose*.yml(N); do …; done
+```
+
+Observed failures: `docker-compose*.yml` and `~/.config/ops-agent/config*`
+with no match killed whole `&&` chains. In `zsh -c` one-shots prefer `fd`; in
+committed zsh scripts add `setopt nullglob` (or the `(N)` qualifier per-glob).
+Bash behaves differently (passes the literal pattern through), which is why a
+snippet tested in bash breaks under zsh.
+
 ## Wrapped-capture permission-denied retry
 
 Some IDE harnesses wrap shell invocations in a capture command that tightens the executing process's permissions. If a script that *should* be executable returns `permission denied` only when wrapped — but works on a manual run — try invoking it with an explicit `/bin/zsh -f`:
@@ -157,7 +208,9 @@ After ruling those out, check [ops-nix-pitfalls](../ops-nix-pitfalls/SKILL.md) f
 - Aliases bypassed (`/bin/cat`, `/bin/ls`, `command <name>`) when exact output matters.
 - Long/nested/JSON payload moved to a script file instead of retried inline.
 - `gh api graphql` / long `jq` filters file-backed up front (gh-graphql-jq-pipelines).
-- Credentials loaded via `kac` / cache; never echoed into output.
+- Credentials loaded via `kac ensure` (exit-code gated); never echoed into output.
+- Subshells launched with `-l` / explicit `PATH` when nix-profile tools are needed.
+- zsh globs guarded (`(N)`, `fd`, or `setopt nullglob`) so no-match doesn't abort.
 
 ## References
 

--- a/chezmoi/dot_config/instructions/agent-reference.md
+++ b/chezmoi/dot_config/instructions/agent-reference.md
@@ -168,6 +168,18 @@ Known gaps and traps (verified on managed darwin hosts):
   are missing or BSD-flavored — use `zsh -lc`, pass `PATH` explicitly, or use
   absolute paths (see the shell-pitfalls skill, "Subshell PATH loss").
 
+## macOS (darwin) Quirks
+
+- **Homebrew cask upgrades can fail on root-owned / TCC-protected apps**
+  (observed: Chrome, Slack). `task switch` treats these as non-fatal, but the
+  upgrade stays blocked until the terminal app (or `brew`'s parent process)
+  has a **Full Disk Access** grant in System Settings → Privacy & Security,
+  and any root-owned copy under `/Applications` is reset
+  (`sudo chown -R "$USER" /Applications/<App>.app` or remove the stale
+  Caskroom entry and reinstall). This needs the user at the keyboard — report
+  it, don't loop retries. VPN-blocked cask downloads are likewise tolerated
+  and retried on a later switch (see hosts/darwin).
+
 ## Instruction Deployment & Regeneration
 
 `agent-defaults.md` is the single source of truth for the always-on prefix.

--- a/chezmoi/dot_config/instructions/agent-reference.md
+++ b/chezmoi/dot_config/instructions/agent-reference.md
@@ -76,8 +76,10 @@ the nix-config repo.
 - **`cache-scan`** — Scan the agent log dir for recent activity. **Terse by
   default** (token-lean, since an agent reads it): a one-line-per-session
   overview plus the commands that hit stderr or were interrupted.
-  `-v|--verbose` adds the command timeline and heuristic keyword scan. Flags:
-  `--days N` (default 2), `--date YYYY-MM-DD`, `--session ID`, `--limit N`.
+  `-v|--verbose` adds the command timeline and heuristic keyword scan;
+  `--classify` aggregates failure categories (with example commands) across
+  the window for trend triage. Flags: `--days N` (default 2; 21 with
+  `--classify`), `--date YYYY-MM-DD`, `--session ID`, `--limit N`.
   De-duplicates the `~/.cache/claude` symlink. Prefer this over hand-rolled
   `rg` sweeps of the log dir.
 - **`sync-to-gdrive`** — Sync `~/.config`, `~/.local`, and `~/.cache/copilot`
@@ -137,10 +139,14 @@ agent hooks / MCP clients via absolute path, never by hand.
   known secrets and token-shaped strings are redacted before write, files are
   `0600`, and `*.thinking.log` is excluded from the gdrive sync profile.
   Treat these logs as sensitive regardless.
-- **`compress-old-cache`** — Compress `~/.cache/<agent>/` files older than 15
-  days with zstd. Agent-aware via `AGENT_NAME` (or explicit `CACHE_DIR`) and
-  self-throttling (`COMPRESS_OLD_CACHE_MIN_INTERVAL_SEC`, default 1800s).
-  Invoked by agent hooks and a daily systemd/launchd timer.
+- **`compress-old-cache`** — Cache maintenance: zstd-compress top-level
+  `~/.cache/<agent>/` files older than 1 day (or over 1 MB), then a retention
+  pass deletes `.zst` archives and untouched subdirectories older than
+  `CACHE_RETENTION_DAYS` (default 548 ≈ 1.5 years).
+  `COMPRESS_OLD_CACHE_DRY_RUN=1` lists retention candidates without deleting.
+  Agent-aware via `AGENT_NAME` (or explicit `CACHE_DIR`) and self-throttling
+  (`COMPRESS_OLD_CACHE_MIN_INTERVAL_SEC`, default 1800s). Invoked by agent
+  hooks and a daily systemd/launchd timer.
 - **`claude-cache-stats`** — Claude `SessionEnd` hook; appends a one-line
   prompt-cache-hit summary per session to `cache-stats.log`.
 - **`aws-mcp-server`** — MCP wrapper for the AWS API MCP server.

--- a/chezmoi/dot_config/instructions/agent-reference.md
+++ b/chezmoi/dot_config/instructions/agent-reference.md
@@ -158,6 +158,16 @@ unzip, p7zip (`7z`/`7za`/`7zr`), alejandra, ncdu, statix, deadnix, nixd,
 markdownlint-cli2, ruff, shellcheck, shfmt, yamllint, taplo, unison, chezmoi,
 glow, gum, tealdeer, scrcpy, file, which, tree, rsync, btop, and lsof.
 
+Known gaps and traps (verified on managed darwin hosts):
+
+- **`psql` is NOT installed.** For a local database, exec into its container:
+  `docker exec -i <db-container> psql -U <user> <db>`. Don't retry bare `psql`.
+- **`nc` is BSD** (`/usr/bin/nc`) — GNU netcat flags (`-q`, `-N`) don't exist.
+- **GNU coreutils (incl. `timeout`, GNU `stat`) live on the login PATH only.**
+  A bare `zsh -c`, `env -i`, or `sudo` gets the system default PATH where they
+  are missing or BSD-flavored — use `zsh -lc`, pass `PATH` explicitly, or use
+  absolute paths (see the shell-pitfalls skill, "Subshell PATH loss").
+
 ## Instruction Deployment & Regeneration
 
 `agent-defaults.md` is the single source of truth for the always-on prefix.

--- a/chezmoi/dot_config/instructions/agent-reference.md
+++ b/chezmoi/dot_config/instructions/agent-reference.md
@@ -20,24 +20,20 @@ Lookup order: `~/.cache` first, then `~/.config`. Known locations by service:
 - **AWS**: `~/.aws/config` and `~/.aws/credentials`; Kion session cache at
   `~/.cache/kion-aws-cache/`. Credentials in `~/.aws/credentials` and
   `AWS_PROFILE` are frequently stale and produce `ExpiredTokenException`.
-  Prefer loading directly from the Kion cache:
-
-  ```sh
-  export AWS_ACCESS_KEY_ID=$(/bin/cat ~/.cache/kion-aws-cache/AWS_ACCESS_KEY_ID)
-  export AWS_SECRET_ACCESS_KEY=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SECRET_ACCESS_KEY)
-  export AWS_SESSION_TOKEN=$(/bin/cat ~/.cache/kion-aws-cache/AWS_SESSION_TOKEN)
-  ```
-
-  Or source `kac` (zsh only, must be sourced) to load from cache or refresh
-  automatically via `gkion` if the cache is stale:
+  Source `kac` (must be sourced; works from bash or zsh) to load from cache or
+  refresh automatically via `gkion` if the cache is stale:
 
   ```sh
   source ~/.local/bin/kac ensure
   ```
 
-  Do this **before** the first `aws` call, not after one fails — for a one-shot,
-  wrap both: `zsh -lc 'source ~/.local/bin/kac ensure >/dev/null && aws …'`. Do
-  not `aws sso login` or `find`/`zstdcat` for the cache path; `kac` owns it.
+  Do this **before** the first `aws` call, not after one fails, and gate on its
+  exit code — for a one-shot, chain both:
+  `zsh -lc 'source ~/.local/bin/kac ensure >/dev/null && aws …'`. Do **not**
+  `cat` the cache files into `export`s (no freshness guarantee — the observed
+  stale-creds anti-pattern; `kac ensure` reads the same files and validates
+  them). Do not `aws sso login` or `find`/`zstdcat` for the cache path; `kac`
+  owns it.
 
 - **GitHub (gh CLI)**: `~/.config/gh/hosts.yml`
 - **SOPS age key** (decrypts all nix-managed secrets):
@@ -57,7 +53,9 @@ the nix-config repo.
     `~/.cache/kion-aws-cache/` as a side-effect.
   - `source ~/.local/bin/kac dump` — write current valid AWS env vars to
     `~/.cache/kion-aws-cache/`
-  - `source ~/.local/bin/kac load` — restore vars from cache into current shell
+  - `source ~/.local/bin/kac load` — restore vars from cache into current
+    shell. Validates but does **not** refresh: expired creds fail instead of
+    self-healing — agents/scripts use `ensure` instead
   - `source ~/.local/bin/kac clear` — unset vars and remove cache files
   - `source ~/.local/bin/kac status` — print whether current/cached creds are
     valid

--- a/chezmoi/dot_local/bin/executable_cache-scan
+++ b/chezmoi/dot_local/bin/executable_cache-scan
@@ -37,9 +37,10 @@ set -euo pipefail
 usage() {
 	cat <<'EOF'
 Usage: cache-scan [--days N] [--date YYYY-MM-DD] [--session ID] [--limit N]
-                  [-t|--transcript] [--diffs] [-v|--verbose]
+                  [-t|--transcript] [--diffs] [--classify] [-v|--verbose]
 
-  --days N         Look back N days by file mtime (default: 2)
+  --days N         Look back N days by file mtime (default: 2; 21 with
+                   --classify)
   --date DATE      Only show records whose header timestamp starts with DATE
   --session ID     Restrict to session log files matching ID
   --limit N        Timeline / decision length (default: 10)
@@ -49,6 +50,10 @@ Usage: cache-scan [--days N] [--date YYYY-MM-DD] [--session ID] [--limit N]
                    alike (needs jq)
       --diffs      Imply -t and also reconstruct the exact edits (Claude
                    old/new strings, Copilot V4A patches); capped by --limit
+      --classify   Aggregate failure categories across the window (incl. .zst
+                   archives): bucket each record's output into named categories
+                   (stale-aws-creds, stat-dialect, zsh-nullglob, …) and print
+                   counts + example commands (needs python3)
   -v|--verbose     Add the command timeline, keyword scan, and full paths
 
 Scans the agent log dir (~/.cache/claude, symlinked to ~/.cache/copilot).
@@ -64,12 +69,14 @@ EOF
 }
 
 days=2
+days_set=0
 date_filter=""
 session=""
 limit=10
 verbose=0
 transcript=0
 diffs=0
+classify=0
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -80,6 +87,7 @@ while [[ $# -gt 0 ]]; do
 			echo "--days must be a number" >&2
 			exit 1
 		}
+		days_set=1
 		;;
 	--date)
 		shift
@@ -111,6 +119,9 @@ while [[ $# -gt 0 ]]; do
 		diffs=1
 		transcript=1
 		;;
+	--classify)
+		classify=1
+		;;
 	-h | --help)
 		usage
 		exit 0
@@ -138,6 +149,119 @@ done
 if [[ ${#roots[@]} -eq 0 ]]; then
 	echo "No cache log dir found under ~/.cache/claude or ~/.cache/copilot"
 	exit 0
+fi
+
+# Classification pass (--classify): the graduated failscan.py aggregator.
+# Buckets each record's OUTPUT text (never the CMD line) into named failure
+# categories, first match wins, and prints counts + example commands. Records
+# whose command merely reads captured logs are skipped so a session that greps
+# these logs does not self-trip. Heuristic — the log carries no exit codes;
+# treat counts as leads, not statistics. Reads .zst archives via zstdcat.
+if ((classify)); then
+	((days_set)) || days=21
+	if ! command -v python3 >/dev/null 2>&1; then
+		echo "cache-scan --classify needs python3" >&2
+		exit 1
+	fi
+	exec python3 - "$days" "${roots[@]}" <<'PY'
+import glob, os, re, subprocess, sys, time
+from collections import defaultdict
+
+days = int(sys.argv[1])
+roots = sys.argv[2:]
+cutoff = time.time() - days * 86400
+
+# (name, regex) — priority order; first match wins per record.
+CATS = [
+    ("stale-aws-creds", r"ExpiredToken|security token included in the request is expired|InvalidClientTokenId|Unable to locate credentials|could not be found.*profile|ExpiredTokenException"),
+    ("stat-dialect", r"stat: illegal option|cannot read file system information for .%|stat: option .* requires|unrecognized option '--format"),
+    ("zsh-nullglob", r"no matches found|zsh: no matches"),
+    ("gh-graphql-jq", r"is not defined|declared but not used|Unexpected .*RCURLY|GraphQL: |jq: error|jq: syntax error|Requires authentication|Could not resolve to a"),
+    ("jq-non-json-input", r"jq: parse error"),
+    ("quoting-heredoc", r"parse error near|unexpected EOF|bad substitution|unmatched .|unexpected end of file|`\\?'.*unexpected"),
+    ("permission-denied", r"[Pp]ermission denied|Operation not permitted|not permitted"),
+    ("cmd-not-found", r"command not found|: not found\b|No such file or directory: .*bin"),
+    ("db-docker-conn", r"Cannot connect to the Docker daemon|[Cc]onnection refused|could not connect to server|psql: error|No such container|Is the server running|ECONNREFUSED"),
+    ("network-tls", r"Could not resolve host|Connection reset by peer|Connection timed out|curl: \(\d+\)|SSL certificate problem|Recv failure"),
+    ("build-ts-node", r"error TS\d|Cannot find module|SyntaxError|ERR_MODULE|ELIFECYCLE|npm ERR!|tsc.*error"),
+    ("nix-build", r"error: builder for|hash mismatch|attribute '.*' missing|infinite recursion|does not provide attribute|error: undefined variable"),
+    ("git-workflow", r"^CONFLICT|\bfatal:|! \[rejected\]|error: failed to push|error: pathspec|not a git repository"),
+    ("file-not-found", r"No such file or directory|cannot access|does not exist"),
+]
+CATS = [(n, re.compile(p, re.M)) for n, p in CATS]
+
+# Skip "self-trip" records: the command is READING a captured log / tool-output
+# artifact whose contents merely contain error text (not a fresh failure).
+META = re.compile(r"copilot-tool-output|/var/folders/\S+/T/|switch_run\.log|"
+                  r"session_\w+\.log|vitest-.*\.log|acceptance-test|"
+                  r"/\.cache/(claude|copilot)/\S+\.log|gh run (view|download)|"
+                  r"\.output\b")
+
+counts = defaultdict(int)
+examples = defaultdict(list)
+total_records = 0
+files = 0
+
+def records(text):
+    parts = re.split(r"(?m)^## \[", text)
+    for p in parts[1:]:
+        yield "## [" + p
+
+def read(path):
+    if path.endswith(".zst"):
+        try:
+            return subprocess.run(["zstdcat", path], capture_output=True,
+                                  text=True, errors="replace").stdout
+        except Exception:
+            return ""
+    with open(path, errors="replace") as f:
+        return f.read()
+
+seen = set()
+for root in roots:
+    for path in glob.glob(os.path.join(root, "session_*.log*")):
+        rp = os.path.realpath(path)
+        if rp in seen or ".skills" in path or ".thinking" in path:
+            continue
+        seen.add(rp)
+        try:
+            if os.path.getmtime(path) < cutoff:
+                continue
+        except OSError:
+            continue
+        files += 1
+        for rec in records(read(path)):
+            total_records += 1
+            cmd = ""
+            m = re.search(r"(?ms)^CMD: (.*?)(?=^STDOUT:|^STDERR:|^---)", rec)
+            if m:
+                cmd = m.group(1).strip().replace("\n", " ")[:90]
+            if META.search(cmd):
+                continue
+            out = ""
+            for mo in re.finditer(r"(?ms)^(?:STDOUT|STDERR):\n(.*?)(?=^---|\Z)", rec):
+                out += mo.group(1)
+            if not out:
+                continue
+            for name, rx in CATS:
+                if rx.search(out):
+                    counts[name] += 1
+                    if len(examples[name]) < 4 and cmd:
+                        examples[name].append(cmd)
+                    break
+
+print(f"cache-scan --classify  files={files}  records={total_records}  window={days}d\n")
+print(f"{'CATEGORY':<20} COUNT")
+for name, _ in CATS:
+    if counts[name]:
+        print(f"{name:<20} {counts[name]}")
+print("\n--- examples (categorized on output, not the command text) ---")
+for name, _ in CATS:
+    if counts[name]:
+        print(f"\n[{name}]  ({counts[name]})")
+        for ex in examples[name]:
+            print(f"  · {ex}")
+PY
 fi
 
 # Emit a log file's contents, transparently decompressing the .zst archives

--- a/chezmoi/dot_local/lib/kion-aws-cache
+++ b/chezmoi/dot_local/lib/kion-aws-cache
@@ -12,6 +12,20 @@ _kion_aws_cache_main() {
 	local -a vars=(AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN)
 	local command="${1:-help}"
 
+	# Harden against PATH-stripped subshells (bare `zsh -c`, `env -i`, sudo):
+	# prepend the dirs that hold gkion/aws so validate/refresh still resolve.
+	# `local` keeps the caller's PATH untouched; exported AWS_* still persist.
+	local PATH="$PATH" tool_dir
+	for tool_dir in \
+		/opt/homebrew/bin \
+		"/etc/profiles/per-user/${USER:-$(id -un)}/bin" \
+		/run/current-system/sw/bin \
+		"$HOME/.nix-profile/bin"; do
+		if [[ -d "$tool_dir" && ":$PATH:" != *":$tool_dir:"* ]]; then
+			PATH="$tool_dir:$PATH"
+		fi
+	done
+
 	# Portable indirect read: print the value of the variable named $1. bash has
 	# ${!name}, zsh has ${(P)name}; eval is the common denominator for both.
 	_kion_aws_cache_get() {
@@ -25,8 +39,11 @@ Usage:
 
 Commands:
   ensure  Load valid creds into current shell, refreshing via gkion if needed.
+          Preferred entry point: run before the first aws call, check its exit
+          code (source ~/.local/bin/kac ensure && aws ...).
   dump    Dump current AWS vars to cache files if they are still valid.
-  load    Load AWS vars from cache files into the current shell.
+  load    Load AWS vars from cache files (validates but does NOT refresh;
+          fails on expired creds — prefer ensure).
   clear   Remove cached AWS vars and unset them from the current shell.
   status  Print whether current and cached credentials appear valid.
 EOF
@@ -84,7 +101,8 @@ EOF
 
 	_kion_aws_cache_dump() {
 		if ! _kion_aws_cache_validate_current; then
-			echo "AWS credentials are expired." >&2
+			echo "Current AWS credentials are expired; nothing dumped." >&2
+			echo "Use: source ~/.local/bin/kac ensure   (refreshes via gkion)" >&2
 			return 1
 		fi
 
@@ -111,7 +129,8 @@ EOF
 		session_token="$(<"$cache_root/AWS_SESSION_TOKEN")"
 
 		if ! _kion_aws_cache_validate_values "$access_key_id" "$secret_access_key" "$session_token"; then
-			echo "AWS credentials are expired." >&2
+			echo "Cached AWS credentials are expired; 'load' does not refresh." >&2
+			echo "Use: source ~/.local/bin/kac ensure   (refreshes via gkion)" >&2
 			return 1
 		fi
 
@@ -149,12 +168,15 @@ EOF
 			return 1
 		fi
 
-		local exports
-		exports=$(gkion env 2>/tmp/kac-ensure-err) || {
+		local exports err_file
+		err_file=$(mktemp "${TMPDIR:-/tmp}/kac-ensure-err.XXXXXX")
+		exports=$(gkion env 2>"$err_file") || {
 			echo "kac ensure: gkion env failed" >&2
-			/bin/cat /tmp/kac-ensure-err >&2
+			/bin/cat "$err_file" >&2
+			rm -f "$err_file"
 			return 1
 		}
+		rm -f "$err_file"
 		eval "$exports"
 	}
 


### PR DESCRIPTION
Executes the TODO.md remediation plan (skill & tool-use flaw fixes from the
cache-log failure scans of 2026-06 + 2026-07-02). One commit per tier.

## Tier 1 — stale AWS creds (dominant failure: 50 archived `ExpiredToken` hits)

- `kion-aws-cache`: prepend known tool dirs to a **function-local `PATH`** so
  PATH-stripped subshells (bare `zsh -c`, `env -i`, `sudo`) still resolve
  `gkion`/`aws`; `load`/`dump` expiry messages now point at `ensure`; `mktemp`
  replaces the fixed `/tmp/kac-ensure-err` path.
- `sec-credentials` + `agent-reference`: removed the raw-`cat`-the-cache-files
  block (the exact observed stale-creds anti-pattern), fixed the stale
  "zsh only" claim, require gating `aws` calls on `kac ensure`'s exit code,
  documented `load` vs `ensure`.
- `shell-pitfalls`: file-backed example for `aws logs` + `jq` one-shots
  (`[$LATEST]` quoting rot).

## Tier 2 — recurring shell traps

- `shell-pitfalls`: new **Subshell PATH loss** and **zsh nullglob** sections.
- `agent-reference`: `psql` not installed (use `docker exec`), BSD `nc`,
  GNU coreutils/`timeout` only on the login PATH.

## Tier 3 — lower / external

- `ops-jira-integration`: `Connection reset by peer` → retry with short
  backoff (VPN bursts).
- `agent-reference`: darwin cask TCC/Full-Disk-Access quirk — report, don't
  retry-loop.

## Tier 4 — cache hygiene & artifact graduation (2026-07-02 scan)

- `compress-old-cache`: **retention pass** — top-level `.zst` archives and
  untouched subdirectories older than `CACHE_RETENTION_DAYS` (default 548d ≈
  1.5 years) are deleted; `COMPRESS_OLD_CACHE_DRY_RUN=1` lists candidates.
  Subdir pruning requires both the dir entry and everything inside to be past
  the window (protects fresh working dirs).
- `cache-scan --classify`: the failure-category aggregator (failscan.py)
  graduated from a session scratchpad into the deployed helper; classifies
  records across the window incl. `.zst` archives.
- `shell-pitfalls`: new **piping non-JSON into `jq`** section.
- Per-ticket bench helpers assessed: not promotable (details in TODO.md).

## Verification

- `kac status`/`load` source clean under **bash, zsh, and `env -i` bash**;
  `load` validated live creds from a stripped PATH (proves the hardening);
  caller `PATH` restored after sourcing.
- `shfmt -d` clean on all three shell files; `markdownlint-cli2` clean on all
  six edited markdown files; pre-commit chain (statix/deadnix/instruction
  checks/gitleaks) green on every commit.
- Retention dry-run: **0 candidates at 548d** (cache history is ~4 months);
  at a 60d test window it correctly selected 3,594 stale archives + 19
  dormant subdirs and excluded recently-touched dirs.
- `cache-scan --classify --days 7` reproduces the Evidence categories
  (stale-aws-creds, build-ts-node, file-not-found, …) on live logs.
- No `agent-defaults.md` change → no instruction regeneration needed.
