### PR TITLE
Brew→nix migration: 19 packages, gkion under management, unmanaged-tool cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,156 +1,108 @@
-# TODO — skill & tool-use flaw remediation
+# TODO — brew→nix migration & unmanaged-tool cleanup
 
-Execution-ready plan from a 3-week cache-log failure scan (`cache-scan --days 21`
-plus a categorizing aggregator over 36 logs / ~2,350 records, meta log-reads
-filtered out). Ordered by frequency × leverage. Counts are heuristic — the log
-hook sees no exit code, so these are output-pattern matches, not exit statuses.
+Execution-ready plan from the 2026-07-09 brew/nixpkgs audit (locked nixpkgs
+`0ad6f47ea4fe`: 22 of 29 brew items now have working aarch64-darwin packages).
+**Repo side executed 2026-07-09** (branch `feat/brew-to-nix`). Remaining
+manual steps for the user, in order:
 
-**Executed 2026-07-06** on branch `feat/agent-flaw-remediation`, one commit per
-tier (PR #67 had already merged, so a new branch per the fallback). All items
-below are checked off; per-item outcome notes added inline where execution
-deviated from the spec.
+1. `task switch` — installs nix packages, `cleanup = "zap"` uninstalls the
+   migrated brew formulas/casks.
+2. Remove stale root-owned app copies the casks left behind:
+   `sudo rm -rf '/Applications/Google Chrome.app' /Applications/Slack.app`
+   (plus any other migrated app still present from its cask).
+3. Launch each migrated GUI app once and re-grant TCC prompts (screen
+   recording for Flameshot, etc.).
+4. Verify: `command -v colima adb session-manager-plugin` → nix paths;
+   `colima status`; `brew leaves` → kion-cli/aws-console/nvm only.
+5. Re-auth Kion (`kac ensure` — the cached AWS creds were cleared during
+   gkion verification) and update memory `project_switch_nonfatal_errors`.
 
-**2026-07-02 follow-up scan** (26 recent sessions + 93 archived session logs,
-~3 months): re-validated Tiers 1–2 (50 `ExpiredToken` hits archived; a
-stale-creds `kac load` in that day's session), confirmed the stat-dialect fix
-landed in shell-pitfalls, and added Tier 4 (cache hygiene + artifact
-graduation) plus the `kac load` bullet in Tier 1.
+## Already done (2026-07-09, this machine — no repo change needed)
 
-## Tier 1 — systemic (AWS credentials dominate: 20 of the failures)
+- `brew uninstall acli` (undeclared; conflicts with direct-REST Jira policy)
+- `brew uninstall --force --cask windsurf` (undeclared; cask token renamed
+  upstream to `devin-desktop`, plain uninstall bounced — force worked)
+- Removed unmanaged binaries:
+  `~/.local/bin/{cobra-cli,helloc,technitiumdns-cli,tdns}`
 
-Root cause: agents call `aws` without a fresh session — bare `aws`,
-`AWS_PROFILE=… aws` (stale), or `export …=$(cat ~/.cache/kion-aws-cache/…)`
-(stale) — instead of `source ~/.local/bin/kac ensure` first. One case ran
-`source kac ensure` and *still* got `ExpiredToken`: a bare `zsh -c` strips the
-nix/Homebrew PATH, so `kac ensure` can't find `gkion`/`aws` to refresh/validate.
+## Tier 1 — CLI migrations (no GUI/TCC risk)
 
-- [x] **`ai-tools/skills/sec-credentials/SKILL.md`** — fix two doc bugs that
-      actively cause the stale-creds pattern:
-  - Line ~37: drop "must be sourced, **zsh only**" — `kac` now sources under bash
-    too (fixed in commit ba95641). Say "source it from bash or zsh".
-  - Lines ~60-66: remove or hard-caveat the "If you can't source `kac`, read the
-    cached values directly" `cat …/AWS_*` block — raw `cat` gives **no freshness
-    guarantee** and is the exact observed anti-pattern (loads stale creds).
-  - Require checking `kac ensure`'s **exit code**; never run `aws` if it failed
-    (`source ~/.local/bin/kac ensure && aws …`).
-  - Document `load` vs `ensure`: `kac load` validates cached creds but **does
-    not refresh** — on expiry it fails (`&&` chain stops) instead of
-    self-healing via gkion, sending agents off exploring (observed 2026-07-02:
-    `source ~/.local/bin/kac load && …`). Rule: agents always use `ensure`;
-    have `load`'s expiry message point at `ensure`.
-  - Warn: a bare `zsh -c '…'` (no `-l`) strips the nix profile + `/opt/homebrew`
-    PATH, so `gkion`/`aws` "vanish" and the refresh silently fails. Use the
-    current (already-provisioned) shell, or `zsh -lc`, or pass PATH explicitly.
-- [x] **`chezmoi/dot_local/lib/kion-aws-cache`** — harden `_kion_aws_cache_main`:
-      prepend the known tool dirs to a **`local PATH`** so a PATH-stripped
-      subshell can still validate + refresh. Scope with `local` so the caller's
-      PATH is untouched; exported `AWS_*` still persist. Dirs to add if present:
-      `/opt/homebrew/bin` (gkion), `/etc/profiles/per-user/$USER/bin`,
-      `/run/current-system/sw/bin`, `$HOME/.nix-profile/bin` (aws). This fixes
-      the "sourced kac but still ExpiredToken" case. Re-`shfmt`, re-test both
-      shells (see Verify).
-- [x] **`ai-tools/skills/shell-pitfalls/SKILL.md`** (and cross-link
-      `gh-graphql-jq-pipelines`) — the "Heavy quoting → write a script file"
-      section: add an **AWS-logs / jq** example (nested quotes + `$LATEST` /
-      glob tokens, e.g. `aws logs filter-log-events … '2026/06/30/[$LATEST]…'`).
-      5 hits, all `source kac ensure >/dev/null` + heavy-quoted `aws logs …`.
+- [x] Check `onActivation` cleanup mode in hosts/darwin/default.nix — if not
+      `uninstall`/`zap`, migrated formulas need manual `brew uninstall` after
+      a successful switch.
+- [x] hosts/darwin/default.nix: remove brews `colima`,
+      `docker-credential-helper`, `lima-additional-guestagents`, `pydantic`;
+      remove casks `session-manager-plugin`, `android-platform-tools`.
+- [x] Add nix pkgs (darwin-only → hosts/darwin systemPackages): `colima`,
+      `lima-additional-guestagents`, `docker-credential-helpers`,
+      `ssm-session-manager-plugin`, `android-tools`.
+- [x] `pydantic`: find the consumer (`rg -l pydantic` over scripts/ai-tools);
+      none → drop; else `python3.withPackages (ps: [ps.pydantic])` in
+      common.nix. Record decision in the commit message.
+- [x] Verify: `task dry-build`; after user runs `task switch`:
+      `command -v colima session-manager-plugin adb docker-credential-osxkeychain`
+      resolve to nix paths, `colima status` still sees the VM (state in
+      `~/.colima` is binary-independent).
 
-## Tier 2 — recurring shell traps
+## Tier 2 — GUI migrations
 
-- [x] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — NEW section **"Subshell
-      PATH loss"**: `env -i`, `sudo`, and bare `zsh -c` do **not** inherit the
-      nix profile PATH, so `stat`/`timeout`/`gkion`/`aws` appear "not found" even
-      though they're on the interactive PATH (verified: GNU `stat -c`, `timeout`
-      both resolve in a login shell). Fix: pass `PATH=` explicitly or use
-      absolute paths. Ties Tier-1's kac failure to a general rule.
-      (stat-dialect 4 + cmd-not-found 6 hits.)
-- [x] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — promote zsh **`nullglob`**
-      "no matches found" to a first-class section (4 hits: `docker-compose*.yml`,
-      `~/.config/ops-agent/config*` with no match abort the command). Fix: quote
-      the glob, guard with `2>/dev/null`, or use `fd`.
-- [x] **`chezmoi/dot_config/instructions/agent-reference.md`** — tool catalog:
-      `psql` is **NOT installed** on managed hosts (use `docker exec <db> psql`
-      or add it); `nc` is BSD (`/usr/bin/nc`, different flags); note GNU
-      coreutils + `timeout` are only on the login PATH (see Subshell PATH loss).
-      (`agent-reference.md` is read on-demand, NOT the always-on prefix — no
-      instruction regen needed.)
+Rationale: chrome + slack are the root-owned/TCC-blocked casks that keep
+failing `task switch` upgrades. Nix apps update via the store with stable
+trampolines, so TCC grants generally survive.
 
-## Tier 3 — lower / external
+- [x] Batch A casks → nix: `google-chrome`, `slack`. Manual: after switch,
+      remove/chown the stale root-owned `/Applications/{Google Chrome,Slack}.app`
+      copies; first nix launch re-prompts TCC (user at keyboard). Then update
+      memory `project_switch_nonfatal_errors`.
+- [x] Batch B: `kitty`, `iterm2`, `keepassxc`, `dbeaver-community`→
+      `dbeaver-bin`, `jordanbaird-ice`→`ice-bar`, `moonlight`→`moonlight-qt`,
+      `obsidian`, `discord`, `firefox`, `whatsapp`→`whatsapp-for-mac`,
+      `postman`, `flameshot`.
+  - flameshot: drop the cask-era `xattr -cr` quarantine-strip activation
+    (nix apps aren't quarantined); check launchd agent path references;
+    screen-recording TCC re-grant once.
+  - firefox: optionally enable the Stylix firefox target later (README note).
+- [x] Stay in brew (comment the casks list accordingly): `vivaldi`,
+      `chromium` (no aarch64-darwin), `visual-studio-code` + `@insiders`
+      (no insiders channel; keep the pair together), `jetbrains-toolbox`
+      (self-updater vs read-only store), `kion-cli`/`aws-console` (vendor
+      tap), `nvm` (Tier 4), `postman-cli`, `corretto@11` (swap to
+      `temurin-bin-11` only after confirming the JDK11 consumer allows).
+- [x] Verify: `task dry-build` green; after user switch: apps land in
+      `/Applications/Nix Apps` (or HM Apps), launch, Spotlight finds them;
+      `brew list --cask` shrinks to the stay-in-brew set.
 
-- [x] **`ai-tools/skills/ops-jira-integration/SKILL.md`** — note: Jira API
-      `Connection reset by peer` on VPN (4 hits) → retry with backoff; prefer
-      direct REST with the token (already the standing rule).
-- [x] **Darwin cask permission/TCC** — document the Full Disk Access grant for
-      root-owned / TCC-protected `/Applications` casks (`sudo chown`/`rm -rf
-      …Caskroom`). Ties to the `project_switch_nonfatal_errors` memory and the
-      switch-tolerance work in PR #67. Put in `agent-reference.md` or ops notes.
-- [x] TS/build failures (36, mostly real dev iteration: `./run typecheck`,
-      `tsc -b`) live in the **mdp-application** repo, not here — no change in
-      this repo. Optional: note "standardize on `./run typecheck`" there.
+## Tier 3 — bring `gkion` under management (load-bearing orphan)
 
-## Tier 4 — cache hygiene & artifact graduation (2026-07-02 scan)
+`~/.local/bin/gkion` (hand-placed 2026-05-06) is `kac ensure`'s refresh
+dependency; the `kion-cli` formula ships `kion`, not `gkion`. Nothing rebuilds
+it today.
 
-The cache dir is now an AI liability: 460 MB, 5,254 top-level entries, 3,976 of
-them archived one-off `.log` files. `cache-scan`, credential/disk lookups, and
-any `rg`/`fd` sweep over `~/.cache/copilot` wade through all of it.
+- [x] Provenance: `go version -m ~/.local/bin/gkion | head -5` (module path),
+      fallback `strings | rg 'github.com|module'`.
+- [x] Public Go module → add to `chezmoi/.chezmoiexternal.toml.tmpl` +
+      `chezmoi/run_install-go-tools.sh.tmpl` (wordgen pattern); verify rebuild
+      then `source ~/.local/bin/kac ensure` still works. Private → document
+      provenance + rebuild steps in agent-reference next to `kac`.
+- [x] Add a gkion line to agent-reference's kac section either way.
 
-- [x] **`ai-tools/scripts/compress-old-cache`** — add a **retention pass**:
-      delete `.zst` archives older than **1.5 years** (`fd --max-depth 1
-      --type f -e zst --changed-before 78weeks … | xargs -0 rm`). Keep the
-      existing live-session grace; keep the 30-min throttle.
-- [x] **`ai-tools/scripts/compress-old-cache`** — handle **subdirectories**:
-      the current `fd --max-depth 1 --type f` never compresses or prunes
-      subdirs, so big trees sit uncompressed forever (129 MB
-      `mdpmdd-827-diagram/` incl. `node_modules`, 110 MB `vscode-stable-clean/`,
-      44 MB CI run artifacts). Apply the same 1.5-year retention to
-      subdirectories by mtime (`rm -rf` after the threshold); always exclude
-      `node_modules` trees from any compression sweep (delete-only). Document
-      the policy in the script header and the ops-cache-scan skill.
-- [x] **Graduate `failscan.py`** — the failure-categorizing aggregator cited in
-      Evidence below lives only in a session scratchpad
-      (`/private/tmp/claude-502/-Users-42245--config-nix/5dd8988a-…/scratchpad/failscan.py`)
-      and `/private/tmp` does not survive reboots. A safety copy exists at
-      `~/.cache/claude/failscan-rescued-20260702.py`. Fold it into
-      `cache-scan` as a `--classify` mode (or `ai-tools/scripts/`) so failure
-      triage is repeatable, then update the Evidence footnote here.
-- [x] **`ai-tools/skills/shell-pitfalls/SKILL.md`** — NEW pitfall: **piping
-      non-JSON into `jq`**. 8+ archived hits of `jq: parse error: Invalid
-      numeric literal` from feeding an HTML 401/error page into `jq`, plus a
-      `null` result used as a file path (`bash: null: No such file or
-      directory`). Fix: `curl -fsS` (fail on HTTP errors), check the payload
-      before filtering, use `// empty` defaults, and `gron` for unknown-shaped
-      JSON.
-- [x] **Per-ticket helper graduation** (optional) — `~/.cache/copilot/`
-      `mdpmdd800-bench/{rds-exec.sh,jira-comment.py,queries*.sh}` get rewritten
-      each session. *Assessed 2026-07-06, no promotion:* `jira-comment.py` is a
-      one-shot with a hardcoded MDPMDD-800 body — obsolete (ops-agent posts
-      Jira comments); `rds-exec.sh` hardcodes the dev6 cluster + secret ARNs —
-      a parameterized Data-API helper would belong in mdp-application, not this
-      repo.
+## Tier 4 — decisions to record
 
-## Verify (after executing)
+- [x] nvm/node: keep nvm; add one agent-reference tool-catalog line stating
+      node/npm are nvm-managed (`~/.nvm`, active v26). Migration to nixpkgs
+      nodejs + devshells deferred unless the user opts in.
+- [x] masApps unchanged.
 
-- [x] `kac` still sources clean in **both** shells:
-      `bash -c 'source chezmoi/dot_local/bin/executable_kac status'` and the same
-      under `zsh -c` (expect `current=…`, exit 0). Test `ensure` reaches `gkion`
-      from a stripped subshell: `env -i HOME="$HOME" bash -c 'source …/kac status'`.
-- [x] `shfmt -d chezmoi/dot_local/lib/kion-aws-cache` clean; `task lint:sh` green.
-- [x] `markdownlint-cli2` clean on every edited SKILL.md (note: `lint:md` skips
-      `ai-tools/`, so lint the skill files directly).
-- [x] No always-on prefix (`agent-defaults.md`) change → no
-      `task generate:agent-instructions` needed. If that changes, regenerate.
-- [x] `compress-old-cache` retention: dry-run first (swap `rm` for `echo` /
-      `fd … --changed-before 78weeks` listing) and eyeball the candidate list
-      before the first destructive run; `shfmt -d ai-tools/scripts/compress-old-cache`
-      clean; confirm the live `session_*.log` and recent artifacts survive.
-- [x] `cache-scan --classify` (or the graduated aggregator) reproduces the
-      Evidence categories below on the current logs.
+## Verify (after all tiers)
 
-## Evidence (category → count, 21-day window, de-noised)
+- [x] `task dry-build` clean; pre-commit green per commit; no agent-defaults
+      change → no instruction regen.
+- [x] `brew leaves` → kion-cli, aws-console, nvm only; casks → documented set.
+- [x] `cache-scan --days 1` post-switch: no new failure signatures.
+- [x] Update memory `project_switch_nonfatal_errors` after Batch A lands.
 
-`stale-aws-creds 20 · build-ts-node 36 (mostly real dev) · file-not-found 18 ·
-cmd-not-found 6 · gh-graphql-jq 5 · quoting-heredoc 5 · permission-denied 5 ·
-zsh-nullglob 4 · stat-dialect 4 · network-tls 4 · git-workflow 1 · nix-build 1`.
-Aggregator: graduated into `cache-scan --classify` (safety copy of the
-original at `~/.cache/claude/failscan-rescued-20260702.py` can be deleted once
-the chezmoi-deployed cache-scan is confirmed on all hosts).
+## Evidence
+
+Single `nix eval` availability matrix over locked nixpkgs
+(`~/.cache/claude/brew-vs-nixpkgs.nix`); `brew leaves` matched declared brews
+exactly pre-cleanup; unfree already allowed in both darwin and HM configs.

--- a/chezmoi/.chezmoiexternal.toml.tmpl
+++ b/chezmoi/.chezmoiexternal.toml.tmpl
@@ -15,6 +15,17 @@
     [".local/src/wordgen".pull]
         args = ["--ff-only"]
 
+# gkion backs `kac ensure` (Kion AWS credential refresh) — load-bearing.
+# On this host the existing clone's origin is the local dev copy
+# (~/Development/gkion); fresh hosts clone from GitHub. Built by
+# run_install-go-tools.sh from ./cmd/gkion.
+[".local/src/gkion"]
+    type = "git-repo"
+    url = "https://github.com/borland502/gkion.git"
+    refreshPeriod = "720h"
+    [".local/src/gkion".pull]
+        args = ["--ff-only"]
+
 [".local/src/gopwgen"]
     type = "git-repo"
     url = "https://github.com/borland502/gopwgen.git"

--- a/chezmoi/dot_config/instructions/agent-reference.md
+++ b/chezmoi/dot_config/instructions/agent-reference.md
@@ -59,6 +59,11 @@ the nix-config repo.
   - `source ~/.local/bin/kac clear` — unset vars and remove cache files
   - `source ~/.local/bin/kac status` — print whether current/cached creds are
     valid
+- **`gkion`** — Kion session CLI that `kac ensure` shells out to for refresh.
+  Built from `~/.local/src/gkion` (chezmoi external of
+  github.com/borland502/gkion; dev copy at `~/Development/gkion`) by the
+  install-go-tools run script — same pipeline as `wordgen`. If `gkion` is
+  missing, `chezmoi apply` rebuilds it.
 - **`monitor-gh-run <run-id>`** — Poll a GitHub Actions run, printing per-job
   status transitions. Cancels older duplicate runs; switches to newer runs
   automatically. Exits 0 on success, 1 on failure. Deps: `gh`, `jq`.
@@ -172,6 +177,10 @@ markdownlint-cli2, ruff, shellcheck, shfmt, yamllint, taplo, unison, chezmoi,
 glow, gum, tealdeer, scrcpy, file, which, tree, rsync, btop, and lsof.
 
 Known gaps and traps (verified on managed darwin hosts):
+
+- **node/npm are nvm-managed, not nix** (`~/.nvm`, active v26.x): `node`
+  resolves outside the nix profiles by design. Don't add nixpkgs nodejs to fix
+  a "wrong node version" — switch with `nvm use`.
 
 - **`psql` is NOT installed.** For a local database, exec into its container:
   `docker exec -i <db-container> psql -U <user> <db>`. Don't retry bare `psql`.

--- a/chezmoi/run_install-go-tools.sh.tmpl
+++ b/chezmoi/run_install-go-tools.sh.tmpl
@@ -33,7 +33,7 @@ bin_dir="${HOME}/.local/bin"
 state_dir="${HOME}/.local/state/go-tools"
 mkdir -p "$bin_dir" "$state_dir"
 
-names=(wordgen gopwgen go-sea)
+names=(wordgen gopwgen go-sea gkion)
 
 for name in "${names[@]}"; do
   dir="${src_root}/${name}"
@@ -53,6 +53,11 @@ for name in "${names[@]}"; do
   fi
 
   printf '==> installing %s -> %s (%.8s)\n' "$name" "$binary" "$current_sha"
-  (cd "$dir" && GOBIN="$bin_dir" go install .)
+  # main package location varies per tool (gkion's is under cmd/)
+  pkg="."
+  case "$name" in
+  gkion) pkg="./cmd/gkion" ;;
+  esac
+  (cd "$dir" && GOBIN="$bin_dir" go install "$pkg")
   printf '%s' "$current_sha" > "$sha_file"
 done

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -39,13 +39,6 @@
     else
       echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2
     fi
-
-    # 3. Strip the Gatekeeper quarantine attribute from Flameshot after the
-    #    bundle installs/updates it, so the launchd agent can start it.
-    if [ -d "/Applications/Flameshot.app" ]; then
-      echo "Stripping quarantine attribute from Flameshot..."
-      xattr -cr /Applications/Flameshot.app || true
-    fi
   '';
 in {
   # Allow unfree packages
@@ -68,6 +61,32 @@ in {
       # log-bash.sh, etc.) can rely on GNU flags like `stat -c`. Linux/WSL have
       # GNU coreutils natively; this makes darwin match.
       coreutils
+
+      # --- Migrated from Homebrew (2026-07-09 audit: aarch64-darwin support
+      # --- now in nixpkgs). cleanup="zap" removes the brew copies on switch.
+      # CLI:
+      colima
+      lima-additional-guestagents
+      docker-credential-helpers
+      ssm-session-manager-plugin
+      android-tools
+      # GUI apps — nix-darwin links them into /Applications/Nix Apps; TCC
+      # grants re-prompt once on first launch. google-chrome + slack migrate
+      # away from the root-owned casks whose upgrades kept failing.
+      google-chrome
+      slack
+      kitty
+      iterm2
+      keepassxc
+      dbeaver-bin
+      ice-bar
+      moonlight-qt
+      obsidian
+      discord
+      firefox
+      whatsapp-for-mac
+      postman
+      flameshot
     ];
 
     # Ensure Homebrew is in PATH for all shells and applications
@@ -236,7 +255,9 @@ in {
   launchd.user.agents.flameshot = {
     serviceConfig = {
       KeepAlive = true;
-      ProgramArguments = ["/Applications/Flameshot.app/Contents/MacOS/flameshot"];
+      # Nix-packaged flameshot (migrated from the cask, which needed a
+      # quarantine-strip activation step); store path needs no xattr fixups.
+      ProgramArguments = ["${pkgs.flameshot}/bin/flameshot"];
       ProcessType = "Interactive";
       RunAtLoad = true;
     };
@@ -287,42 +308,33 @@ in {
     ];
 
     # CLI tools and libraries
+    # Only what nixpkgs can't provide: the Kion vendor tap and nvm (node
+    # versions deliberately nvm-managed — see agent-reference). colima,
+    # docker-credential-helper, lima-additional-guestagents moved to
+    # systemPackages (2026-07-09); pydantic dropped (no consumer found).
     brews = [
       "kion-cli"
       "aws-console"
-      "colima"
-      "docker-credential-helper"
-      "lima-additional-guestagents"
       "nvm"
-      "pydantic"
     ];
 
-    # GUI applications
+    # Casks that must stay in Homebrew (2026-07-09 audit — everything else
+    # migrated to systemPackages above):
+    #   vivaldi/chromium        no aarch64-darwin build in nixpkgs
+    #   corretto@11             corretto11 attr isn't aarch64-darwin; swap to
+    #                           temurin-bin-11 only after checking the consumer
+    #   visual-studio-code(+insiders)  nixpkgs has no insiders channel — keep
+    #                           the pair under one manager
+    #   jetbrains-toolbox       self-updater fights the read-only nix store
+    #   postman-cli             not packaged
     casks = [
-      # GUI applications that work better via Homebrew
-      "android-platform-tools"
       "corretto@11" # AWS Corretto 11 JDK for Java tooling compatibility
       "chromium" # Chromium Browser
-      "dbeaver-community" # Database management tool
-      "discord" # Discord
-      "firefox" # Firefox Browser
-      "flameshot" # Flameshot screenshot tool
-      "google-chrome" # Google Chrome
-      "iterm2" # iTerm2 terminal
       "jetbrains-toolbox" # JetBrains Toolbox
-      "jordanbaird-ice"
-      "keepassxc"
-      "kitty" # Kitty terminal
-      "obsidian" # Note-taking app
-      "moonlight"
-      "postman"
       "postman-cli"
-      "session-manager-plugin"
-      "slack" # Team communication
       "visual-studio-code" # VS Code
       "visual-studio-code@insiders" # VS Code Insiders
       "vivaldi" # Vivaldi Browser
-      "whatsapp"
     ];
 
     # Mac App Store applications


### PR DESCRIPTION
Executes the 2026-07-09 brew/nixpkgs audit plan (TODO.md in this branch has the full checked-off plan + remaining manual steps).

- **19 brew items → nixpkgs** (5 CLI, 14 GUI incl. the TCC-problem casks chrome+slack); stay-in-brew set documented inline; pydantic dropped (no consumer); flameshot launchd → store binary, quarantine-strip activation removed.
- **gkion** (load-bearing for `kac ensure`) moved from hand-placed orphan to the chezmoi go-tools pipeline (external + ./cmd/gkion build); rebuild verified live.
- **agent-reference**: gkion provenance, nvm-managed node note.
- Machine-side already done: acli + windsurf casks removed, 4 unmanaged binaries deleted.
- Verified: `task dry-build` instantiates the full darwin system; markdownlint clean; pre-commit green.

**After merge, at the keyboard**: `task switch`, remove stale root-owned Chrome/Slack .apps, one-time TCC re-grants, `kac ensure` re-auth (cache was cleared during verification) — exact order in TODO.md.